### PR TITLE
Add Entity.GetPlayerOwner() + player.cantool Event

### DIFF
--- a/EVENTS.md
+++ b/EVENTS.md
@@ -10,6 +10,8 @@
     Should return the string to show in the toast, or empty string if the undoable is redundant and should be skipped over (eg. if the weld was already removed)
 - "spawnlists.initialize"
   - Takes no parameters; you're expected to call `ModelSelector.AddToSpawnlist( "screen", string[] models)`
+- "player.cantool": called by traces.
+  - Takes a single CanToolParams parameter. Writing `params.preventDefault = true` will prevent the tool action.
 - "player.simulate"
   - `Event.Run( "player.simulate", SandboxPlayer player )`
 - "player.killed"

--- a/code/Player.Use.cs
+++ b/code/Player.Use.cs
@@ -45,6 +45,10 @@ partial class SandboxPlayer
 		// Still no good? Bail.
 		if ( !IsValidUseEntity( ent ) ) return null;
 
+		tr = CanToolParams.RunCanTool( this, "use", tr );
+		if ( !tr.Hit )
+			return null;
+
 		return ent;
 	}
 

--- a/code/Player.cs
+++ b/code/Player.cs
@@ -346,4 +346,13 @@ public partial class SandboxPlayer : Player
 			Camera.Main.SetViewModelCamera( 90f );
 		}
 	}
+
+	[Event( "entity.spawned" )]
+	public static void OnSpawned( Entity spawned, Entity owner )
+	{
+		if ( owner is Player player )
+		{
+			spawned.SetPlayerOwner( player );
+		}
+	}
 }

--- a/code/Tool.CanTool.cs
+++ b/code/Tool.CanTool.cs
@@ -1,0 +1,39 @@
+namespace Sandbox
+{
+	public class CanToolParams
+	{
+		public Player player;
+		public string toolName;
+		public TraceResult tr;
+		public Entity entity;
+		public bool preventDefault = false;
+
+		public static TraceResult RunCanTool( Player player, string toolName, TraceResult tr )
+		{
+			if ( Game.IsClient )
+			{
+				return tr; // PlayerOwner table is currently serverside only
+			}
+			if ( !tr.Entity.IsValid() || tr.Entity.IsWorld )
+			{
+				return tr;
+			}
+			var canToolParams = new CanToolParams
+			{
+				player = player,
+				toolName = toolName,
+				tr = tr,
+				entity = tr.Entity,
+			};
+			Event.Run( "player.cantool", canToolParams );
+			if ( canToolParams.preventDefault )
+			{
+				return new TraceResult();
+			}
+			else
+			{
+				return tr;
+			}
+		}
+	}
+}

--- a/code/Tool.cs
+++ b/code/Tool.cs
@@ -175,15 +175,22 @@ namespace Sandbox.Tools
 			Parent?.CreateHitEffects( pos, normal, continuous );
 		}
 
-		public virtual TraceResult DoTrace()
+		public virtual TraceResult DoTrace( bool checkCanTool = true )
 		{
 			var startPos = Owner.EyePosition;
 			var dir = Owner.EyeRotation.Forward;
 
-			return Trace.Ray( startPos, startPos + (dir * MaxTraceDistance) )
+			var tr = Trace.Ray( startPos, startPos + (dir * MaxTraceDistance) )
 				.WithAnyTags( "solid", "nocollide" )
 				.Ignore( Owner )
 				.Run();
+
+			if ( checkCanTool && tr.Entity.IsValid() && !tr.Entity.IsWorld )
+			{
+				return CanToolParams.RunCanTool( Owner, ClassName, tr );
+			}
+
+			return tr;
 		}
 
 		protected string GetConvarValue( string name, string defaultValue = null )

--- a/code/entities/Entity.ownership.cs
+++ b/code/entities/Entity.ownership.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+using Sandbox;
+
+public static class EntityOwnershipExtensions
+{
+	private static Dictionary<Entity, Player> PlayerOwners { get; set; } = new();
+	public static Player GetPlayerOwner( this Entity ent )
+	{
+		Game.AssertServer();
+		return PlayerOwners.GetValueOrDefault( ent );
+	}
+	public static void SetPlayerOwner( this Entity ent, Player player )
+	{
+		PlayerOwners[ent] = player;
+	}
+}

--- a/code/entities/Entity.ownership.cs
+++ b/code/entities/Entity.ownership.cs
@@ -11,6 +11,7 @@ public static class EntityOwnershipExtensions
 	}
 	public static void SetPlayerOwner( this Entity ent, Player player )
 	{
+		Game.AssertServer();
 		PlayerOwners[ent] = player;
 	}
 }

--- a/code/tools/BoxShooter.cs
+++ b/code/tools/BoxShooter.cs
@@ -13,7 +13,7 @@
 			{
 				if ( Input.Pressed( "reload" ) )
 				{
-					var tr = Trace.Ray( Owner.EyePosition, Owner.EyePosition + Owner.EyeRotation.Forward * 4000 ).Ignore( Owner ).Run();
+					var tr = DoTrace( false );
 
 					if ( tr.Entity is ModelEntity ent && !string.IsNullOrEmpty( ent.GetModelName() ) )
 					{

--- a/code/tools/Constraint.cs
+++ b/code/tools/Constraint.cs
@@ -60,12 +60,7 @@ namespace Sandbox.Tools
 				if ( !Game.IsServer )
 					return;
 
-				var startPos = Owner.EyePosition;
-				var dir = Owner.EyeRotation.Forward;
-
-				var tr = Trace.Ray( startPos, startPos + dir * MaxTraceDistance )
-					.Ignore( Owner )
-					.Run();
+				var tr = DoTrace();
 
 				if ( !tr.Hit || !tr.Entity.IsValid() )
 				{

--- a/code/tools/PhysGun.cs
+++ b/code/tools/PhysGun.cs
@@ -113,6 +113,7 @@ public partial class PhysGun : Carriable
 			.Ignore( this )
 			.OnTraceEvent( Owner ) // SandboxPlus addition for Stargate support
 			.Run();
+		tr = CanToolParams.RunCanTool( Owner as Player, ClassName, tr );
 
 		if ( !tr.Hit || !tr.Entity.IsValid() || tr.Entity.IsWorld ) return;
 		if ( tr.Entity.Tags.Has( PhysgunBlockTag ) ) return;
@@ -152,6 +153,7 @@ public partial class PhysGun : Carriable
 			.Ignore( this )
 			.OnTraceEvent( Owner ) // SandboxPlus addition for Stargate support
 			.Run();
+		tr = CanToolParams.RunCanTool( Owner as Player, ClassName, tr );
 
 		if ( !tr.Hit || !tr.Entity.IsValid() || tr.Entity.IsWorld || tr.StartedSolid ) return;
 		if ( tr.Entity.Tags.Has( PhysgunBlockTag ) ) return;

--- a/code/tools/WhatIsThat.cs
+++ b/code/tools/WhatIsThat.cs
@@ -37,6 +37,10 @@ namespace Sandbox.Tools
 						{
 							message += $" weighing {prop.PhysicsBody.Mass}";
 						}
+						if ( prop.GetPlayerOwner().IsValid() )
+						{
+							message += $" owned by {prop.GetPlayerOwner()}";
+						}
 					}
 					// todo: how do print to chat/etc?
 					Log.Info( message );


### PR DESCRIPTION
Minimum functionality required for a Prop Protection to be implemented.

Example minimalist Prop Protection that would treat all tools (including "tool_wiring" & "use" & "physgun") the same, and only allows the Entity's owner player to trace:

```
[Event( "player.cantool" )]
public static void OnCanTool( CanToolParams canToolParams )
{
	if ( canToolParams.entity.GetPlayerOwner().IsValid() && canToolParams.player != canToolParams.entity.GetPlayerOwner() )
	{
		canToolParams.preventDefault = true;
	}
}
```