### PR TITLE
Add move/rotate functionality to the constraint tool

### DIFF
--- a/code/tools/Constraint.cs
+++ b/code/tools/Constraint.cs
@@ -56,6 +56,7 @@ namespace Sandbox.Tools
 		private bool wasFrozen;
 		private bool wasSleeping;
 		private bool wasMotionEnabled;
+		private float rotationBuildUp;
 		private const float RotateSpeed = 30.0f;
 
 		// Dynamic entrypoint for optional Wirebox support, if installed
@@ -89,9 +90,30 @@ namespace Sandbox.Tools
 						Reset();
 					}
 
-					var rotation = Rotation.FromAxis( trace2.Normal, Input.MouseDelta.x * RotateSpeed * Time.Delta );
+					var rotationAmount = Input.MouseDelta.x * RotateSpeed * Time.Delta;
+					var rotationSnap = float.Parse( GetConvarValue( "tool_constraint_rotate_snap", "0" ) );
+					if ( rotationSnap >= 0.001 )
+					{
+						rotationBuildUp += rotationAmount;
 
-					trace1.Entity.Transform = trace1.Entity.Transform.RotateAround( trace2.HitPosition, rotation );
+						if ( rotationBuildUp <= -rotationSnap )
+						{
+							rotationBuildUp = 0;
+							var rotation = Rotation.FromAxis( trace2.Normal, -rotationSnap );
+							trace1.Entity.Transform = trace1.Entity.Transform.RotateAround( trace2.HitPosition, rotation );
+						}
+						else if (rotationBuildUp >= rotationSnap)
+						{
+							rotationBuildUp = 0;
+							var rotation = Rotation.FromAxis( trace2.Normal, rotationSnap );
+							trace1.Entity.Transform = trace1.Entity.Transform.RotateAround( trace2.HitPosition, rotation );
+						}
+					}
+					else
+					{
+						var rotation = Rotation.FromAxis( trace2.Normal, rotationAmount );
+						trace1.Entity.Transform = trace1.Entity.Transform.RotateAround( trace2.HitPosition, rotation );
+					}
 				}
 
 				var tr = DoTrace();
@@ -169,6 +191,7 @@ namespace Sandbox.Tools
 							if ( wantsRotation )
 							{
 								stage = ConstraintToolStage.Rotating;
+								rotationBuildUp = 0;
 								CreateHitEffects( tr.EndPosition, tr.Normal );
 								return;
 							}

--- a/code/tools/Constraint.cs
+++ b/code/tools/Constraint.cs
@@ -36,13 +36,27 @@ namespace Sandbox.Tools
 		[ConVar.ClientData( "tool_constraint_freeze_target" )] public static string _9 { get; set; } = "1";
 		[ConVar.ClientData( "tool_constraint_nocollide_target" )] public static string _10 { get; set; } = "1";
 
+		private enum ConstraintToolStage {
+			Waiting,
+			Moving,
+			Rotating,
+			Applying,
+			ConstraintController,
+			Removing,
+		}
+		
 		[Net, Predicted]
-		private int stage { get; set; } = 0;
+		private ConstraintToolStage stage { get; set; } = ConstraintToolStage.Waiting;
 		private TraceResult trace1;
 		private TraceResult trace2;
+		private PhysicsPoint point1;
+		private PhysicsPoint point2;
 		private PhysicsJoint createdJoint;
 		private Func<string> createdUndo;
-
+		private bool wasFrozen;
+		private bool wasSleeping;
+		private bool wasMotionEnabled;
+		private const float RotateSpeed = 30.0f;
 
 		// Dynamic entrypoint for optional Wirebox support, if installed
 		public static Action<Player, TraceResult, ConstraintType, PhysicsJoint, Func<string>> CreateWireboxConstraintController;
@@ -65,9 +79,20 @@ namespace Sandbox.Tools
 
 			using ( Prediction.Off() )
 			{
-
 				if ( !Game.IsServer )
 					return;
+
+				if ( stage == ConstraintToolStage.Rotating )
+				{
+					if ( !trace1.Body.IsValid() || !trace2.Body.IsValid() )
+					{
+						Reset();
+					}
+
+					var rotation = Rotation.FromAxis( trace2.Normal, Input.MouseDelta.x * RotateSpeed * Time.Delta );
+
+					trace1.Entity.Transform = trace1.Entity.Transform.RotateAround( trace2.HitPosition, rotation );
+				}
 
 				var tr = DoTrace();
 
@@ -75,16 +100,18 @@ namespace Sandbox.Tools
 				{
 					return;
 				}
-
-
+				
 				if ( Input.Pressed( "attack1" ) )
 				{
-					if ( stage == 0 )
+					if ( stage == ConstraintToolStage.Waiting )
 					{
 						trace1 = tr;
-						stage++;
+						stage = ConstraintToolStage.Moving;
+						CreateHitEffects( tr.EndPosition, tr.Normal );
+						return;
 					}
-					else if ( stage == 1 )
+
+					if ( stage == ConstraintToolStage.Moving )
 					{
 						trace2 = tr;
 						if ( !trace1.Entity.IsValid() )
@@ -92,34 +119,92 @@ namespace Sandbox.Tools
 							Reset();
 							return;
 						}
+
 						if ( trace1.Entity.IsWorld && trace2.Entity.IsWorld )
 						{
 							return; // can't both be world
 						}
-						PhysicsPoint point1;
-						PhysicsPoint point2;
+						
 						if ( GetConvarValue( "tool_constraint_move_target" ) != "0" )
 						{
+							var wantsRotation = GetConvarValue( "tool_constraint_rotate_target" ) != "0" && !trace1.Entity.IsWorld;
+						
+							wasFrozen = (trace1.Body.BodyType == PhysicsBodyType.Static);
+							wasMotionEnabled = trace1.Body.MotionEnabled;
+							wasSleeping = trace1.Body.Sleeping;
+
+							if ( wantsRotation )
+							{
+								trace1.Body.Sleeping = false;
+								trace1.Body.BodyType = PhysicsBodyType.Keyframed;
+								trace1.Body.MotionEnabled = false;
+							}
+							
 							var offset = float.Parse( GetConvarValue( "tool_constraint_move_offset" ) );
 							if ( GetConvarValue( "tool_constraint_move_percent" ) != "0" )
 							{
 								offset = GetEntityOffsetPercent( offset, trace1 );
 							}
-							point1 = PhysicsPoint.World( trace1.Body, trace1.EndPosition + trace1.Normal * offset, Rotation.LookAt( -trace1.Normal, trace1.Direction ) );
-							point2 = PhysicsPoint.World( trace2.Body, trace2.EndPosition, Rotation.LookAt( trace2.Normal, trace2.Direction ) );
-						}
-						else
-						{
-							point1 = PhysicsPoint.World( trace1.Body, trace2.EndPosition, trace2.Entity.Rotation );
-							point2 = PhysicsPoint.World( trace2.Body, trace2.EndPosition, trace2.Entity.Rotation );
+
+							// Calculate the new rotation
+							var transform = trace1.Entity.Transform;
+							var rotation = trace1.Entity.Rotation;
+							var axis1Rotation = transform.RotationToLocal(Rotation.LookAt( trace1.Normal ));
+							var axis2Rotation = transform.RotationToLocal(Rotation.LookAt( -trace2.Normal ));
+							var rotationDifference = Rotation.Difference( axis1Rotation, axis2Rotation );
+							var newRotation = rotation * rotationDifference;
+							
+							// The position offset has to be calculated before we apply the rotation
+							var offsetPosition = trace1.EndPosition + trace1.Normal * offset;
+							var localOffset = transform.PointToLocal( offsetPosition );
+							
+							transform.Rotation = newRotation;
+							
+							// Apply our offset and move to the new location
+							var newPosition = trace2.EndPosition - transform.PointToWorld( localOffset );
+							transform.Position += newPosition;
+
+							trace1.Entity.Transform = transform;
+							
+							if ( wantsRotation )
+							{
+								stage = ConstraintToolStage.Rotating;
+								CreateHitEffects( tr.EndPosition, tr.Normal );
+								return;
+							}
 						}
 
-						trace1.Body.Sleeping = true;
-						if ( GetConvarValue( "tool_constraint_freeze_target" ) != "0" && !trace1.Entity.IsWorld )
+						// Don't return here because we can skip straight to applying
+						stage = ConstraintToolStage.Applying;
+					}
+
+					if ( stage == ConstraintToolStage.Rotating )
+					{
+						// Don't return here because we can skip straight to applying
+						stage = ConstraintToolStage.Applying;
+					}
+
+					if ( stage == ConstraintToolStage.Applying )
+					{
+						if ( !trace1.Entity.IsWorld )
 						{
-							trace1.Body.BodyType = PhysicsBodyType.Static;
+							if ( GetConvarValue( "tool_constraint_freeze_target" ) != "0" )
+							{
+								trace1.Body.Sleeping = true;
+								trace1.Body.MotionEnabled = wasMotionEnabled;
+								trace1.Body.BodyType = PhysicsBodyType.Static;
+							}
+							else
+							{
+								trace1.Body.MotionEnabled = wasMotionEnabled;
+								trace1.Body.Sleeping = wasSleeping;
+								trace1.Body.BodyType = wasFrozen ? PhysicsBodyType.Static : PhysicsBodyType.Dynamic;
+							}
 						}
 
+						point1 = PhysicsPoint.World( trace1.Body, trace2.EndPosition, trace2.Entity.Rotation );
+						point2 = PhysicsPoint.World( trace2.Body, trace2.EndPosition, trace2.Entity.Rotation );
+						
 						if ( Type == ConstraintType.Weld )
 						{
 							var joint = PhysicsJoint.CreateFixed(
@@ -280,7 +365,7 @@ namespace Sandbox.Tools
 							trace1.Body.Sleeping = false;
 						}
 					}
-					else if ( stage == 2 )
+					else if ( stage == ConstraintToolStage.ConstraintController )
 					{
 						// only reachable if Wirebox's installed
 						if ( WireboxSupport )
@@ -302,17 +387,17 @@ namespace Sandbox.Tools
 					{
 						return;
 					}
-					if ( stage == 0 )
+					if ( stage == ConstraintToolStage.Waiting )
 					{
 						trace1 = tr;
-						stage++;
+						stage = ConstraintToolStage.Removing;
 						if ( Input.Down( "walk" ) )
 						{
 							RemoveConstraints( Type, tr );
 							Reset();
 						}
 					}
-					else if ( stage == 1 )
+					else if ( stage == ConstraintToolStage.Removing )
 					{
 						trace2 = tr;
 						if ( !trace1.Entity.IsValid() )
@@ -404,27 +489,27 @@ namespace Sandbox.Tools
 			var desc = $"Constraint entities together using {Type} constraint";
 			if ( Type == ConstraintType.Axis )
 			{
-				if ( stage == 0 )
+				if ( stage == ConstraintToolStage.Waiting )
 				{
 					desc += $"\nFirst, {Input.GetButtonOrigin( "attack1" )} the part that spins (eg. wheel).";
 				}
-				else if ( stage == 1 )
+				else if ( stage == ConstraintToolStage.Moving )
 				{
 					desc += $"\nSecond, {Input.GetButtonOrigin( "attack1" )} the base. Hold {Input.GetButtonOrigin( "run" )} to use wheel's center of mass.";
 				}
 			}
 			else
 			{
-				if ( stage == 0 )
+				if ( stage == ConstraintToolStage.Waiting )
 				{
 					desc += $"\nFirst, {Input.GetButtonOrigin( "attack1" )} the part to attach.";
 				}
-				else if ( stage == 1 )
+				else if ( stage == ConstraintToolStage.Moving )
 				{
 					desc += $"\nSecond, {Input.GetButtonOrigin( "attack1" )} the base.";
 				}
 			}
-			if ( stage == 0 )
+			if ( stage == ConstraintToolStage.Waiting )
 			{
 				desc += $"\n{Input.GetButtonOrigin( "attack2" )} to nudge ({Input.GetButtonOrigin( "run" )} for reverse)";
 				desc += $"\n{Input.GetButtonOrigin( "reload" )} to select an entity to remove {Type} constraint ({Input.GetButtonOrigin( "walk" )} to remove all {Type} constraints)";
@@ -432,11 +517,11 @@ namespace Sandbox.Tools
 			}
 			if ( WireboxSupport )
 			{
-				if ( stage == 1 )
+				if ( stage == ConstraintToolStage.Moving )
 				{
 					desc += $"\nHold {Input.GetButtonOrigin( "walk" )} to begin creating a Wire Constraint Controller";
 				}
-				else if ( stage == 2 )
+				else if ( stage == ConstraintToolStage.ConstraintController )
 				{
 					desc += $"\nFinally, place the Wire Constraint Controller";
 				}
@@ -456,7 +541,7 @@ namespace Sandbox.Tools
 			{
 				createdJoint = joint;
 				createdUndo = undo;
-				stage = 2;
+				stage = ConstraintToolStage.ConstraintController;
 				return;
 			}
 			Reset();
@@ -496,7 +581,7 @@ namespace Sandbox.Tools
 
 		private void Reset()
 		{
-			stage = 0;
+			stage = ConstraintToolStage.Waiting;
 		}
 
 		public override void Activate()

--- a/code/tools/ConstraintToolConfig.razor
+++ b/code/tools/ConstraintToolConfig.razor
@@ -43,7 +43,6 @@
 			style="margin-bottom: 20px;"
 		/>
 	}
-	@*
 	<ToolCheckbox
 		Label="Rotate Target? (after moving)"
 		Convar="tool_constraint_rotate_target"
@@ -58,7 +57,6 @@
 			Convar="tool_constraint_rotate_snap"
 		/>
 	}
-	*@
 	<ToolCheckbox
 		Label="Freeze Target"
 		Convar="tool_constraint_freeze_target"


### PR DESCRIPTION
I fixed the move functionality (it didn't appear to move the entity most of the time), and added the code for rotation to work. I'd like to lock the camera in place while the rotation is happening, but I'm not sure how to go about that right now.

I also refactored the tool stages to use an enum. I've always found using an int for these incredibly confusing in Garry's Mod, and in this case it was also causing bugs because different buttons were sharing stage numbers. Now it should be very clear what the tool is doing when looking at the code. Normally I'd do this as a separate pull request, but I forgot to branch before I started on the rotation code.