### PR TITLE
Create Undo system

### DIFF
--- a/Code/Components/Player/Player.cs
+++ b/Code/Components/Player/Player.cs
@@ -14,9 +14,18 @@ public sealed partial class Player : Component, Component.IDamageable, PlayerCon
 	[Property] public GameObject Body { get; set; }
 	[Property, Range( 0, 100 ), Sync] public float Health { get; set; } = 100;
 
+	[Property] public string Name { get; set; } = "Unknown";
+	[Property] public SteamId SteamId { get; set; } = 0UL;
+	[Property] public SteamId PartyId { get; set; } = 0UL;
+
 	public bool IsDead => Health <= 0;
 	public Transform EyeTransform => Controller.EyeTransform;
 	public Ray AimRay => new( EyeTransform.Position, EyeTransform.Rotation.Forward );
+
+	public bool isInParty()
+	{
+		return PartyId != 0UL;
+	}
 
 	/// <summary>
 	/// Creates a ragdoll but it isn't enabled

--- a/Code/Components/PlayerController/PlayerController.DefaultControls.cs
+++ b/Code/Components/PlayerController/PlayerController.DefaultControls.cs
@@ -75,6 +75,19 @@ public sealed partial class PlayerController : Component
 		InputMove();
 		UpdateDucking( Input.Down( "duck" ) );
 		InputJump();
+
+		if ( Input.Pressed( "undo" ) ) TriggerUndo();
+		if ( Input.Pressed( "redo" ) ) TriggerRedo();
+	}
+
+	private void TriggerUndo()
+	{
+		ConsoleSystem.Run( "undo" );
+	}
+
+	private void TriggerRedo()
+	{
+		Log.Info( "REDO, not yet implemented" );
 	}
 
 	void UpdateHeadroom()

--- a/Code/Components/Tools/Weld.cs
+++ b/Code/Components/Tools/Weld.cs
@@ -21,6 +21,8 @@ public class Weld : BaseTool
 
 			propHelper.Weld( welded );
 
+			UndoSystem.Add( this.Owner, ReadyUndo( propHelper, welded ));
+
 			welded = null;
 			return true;
 		}
@@ -28,12 +30,12 @@ public class Weld : BaseTool
 		return false;
 	}
 
-	public override bool Secondary( SceneTraceResult trace )
+	public override bool Reload( SceneTraceResult trace )
 	{
 		if ( !trace.Hit )
 			return false;
 
-		if ( Input.Pressed( "attack2" ) && trace.GameObject.Components.TryGet<PropHelper>( out var propHelper ) )
+		if ( Input.Pressed( "reload" ) && trace.GameObject.Components.TryGet<PropHelper>( out var propHelper ) )
 		{
 			propHelper.Unweld();
 
@@ -42,5 +44,15 @@ public class Weld : BaseTool
 		}
 
 		return false;
+	}
+
+	private Func<string> ReadyUndo( PropHelper propHelper, GameObject from)
+	{
+		return () =>
+		{
+			propHelper.Unweld( from );
+
+			return "Un-welded two objects";
+		};
 	}
 }

--- a/Code/Components/Tools/Wheel.cs
+++ b/Code/Components/Tools/Wheel.cs
@@ -49,6 +49,8 @@ public class Wheel : BaseTool
 
 			propHelper.Hinge( trace.GameObject, trace.EndPosition, trace.Normal );
 
+			UndoSystem.Add( this.Owner, ReadyUndo( wheel, trace.GameObject ) );
+
 			return true;
 		}
 
@@ -71,6 +73,17 @@ public class Wheel : BaseTool
 	{
 		timeSinceDisabled = 0;
 		PreviewModel?.Destroy();
+	}
+
+	private Func<string> ReadyUndo(GameObject wheel, GameObject other)
+	{
+		return () =>
+		{
+			// TODO: When UnHinge works, uncomment this
+			//wheel.GetComponent<PropHelper>().UnHinge( other );
+			wheel.Destroy();
+			return "Undid wheel creation";
+		};
 	}
 
 	GameObject SpawnWheel( SceneTraceResult trace )

--- a/Code/Components/UndoSystem/Undo.cs
+++ b/Code/Components/UndoSystem/Undo.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using Sandbox;
+
+public class Undo
+{
+	public Player Creator;
+	public GameObject Prop;
+	public Func<string> UndoCallback;
+	public float Time;
+	public bool Avoid;
+
+	public Undo( Player creator )
+	{
+		Creator = creator;
+		Time = Sandbox.Time.Now;
+		Avoid = false;
+	}
+	public Undo( Player creator, GameObject prop ) : this( creator )
+	{
+		Prop = prop;
+	}
+}

--- a/Code/Components/UndoSystem/UndoSystem.cs
+++ b/Code/Components/UndoSystem/UndoSystem.cs
@@ -1,0 +1,96 @@
+using Sandbox;
+using Sandbox.Diagnostics;
+using Sandbox.Events;
+
+public sealed class UndoSystem : GameObjectSystem<UndoSystem>
+{
+	public UndoSystem( Scene scene ) : base( scene )
+	{
+	}
+
+	private static Dictionary<long, List<Undo>> Undos = new();
+
+	private static List<Undo> Get(SteamId id)
+	{
+		if ( !Undos.ContainsKey( id ) )
+			Undos.Add( id, new List<Undo>() );
+
+		return Undos[id];
+	}
+
+	private static Undo GetFirstAndRemove(SteamId id)
+	{
+		if ( !Undos.ContainsKey( id ) )
+			Undos.Add( id, new List<Undo>() );
+
+		if ( Undos[id].Count == 0 ) return null;
+
+		Undo undo = Undos[id][0];
+		Undos[id].RemoveAt( 0 );
+
+		return undo;
+	}
+
+	private static void Add(SteamId id, Undo undo)
+	{
+		if ( !Undos.ContainsKey( id ) )
+		{
+			Undos.Add( id, new List<Undo>() );
+		}
+
+		Undos[id].Insert( 0, undo );
+	}
+
+	public static bool Remove( SteamId steamId, Undo undo )
+	{
+		if ( !Undos.ContainsKey( steamId ) )
+			Undos.Add( steamId, new List<Undo>() );
+
+		return Undos[steamId].Remove( undo );
+	}
+
+	[ConCmd( "undo" )]
+	public static void PlayerUndo()
+	{
+		var player = Player.FindLocalPlayer();
+		if ( !player.IsValid() )
+			return;
+
+		Undo undo = GetFirstAndRemove( player.SteamId );
+
+		if (undo != null)
+		{
+			if ( undo.UndoCallback != null )
+			{
+				var undoMessage = undo.UndoCallback();
+				if ( undoMessage != "" )
+				{
+					HintFeed.AddHint( "", undoMessage );
+					CreateUndoParticles( Vector3.Zero );
+				}
+			}
+		}
+	}
+
+	public static void Add( Player creator, Func<string> callback, bool avoid = false )
+	{
+		if ( creator == null ) return;
+
+		var undo = new Undo( creator )
+		{
+			UndoCallback = callback,
+			Avoid = avoid
+		};
+
+		Add( creator.SteamId, undo );
+	}
+
+	[Rpc.Broadcast]
+	public static void CreateUndoParticles( Vector3 pos )
+	{
+		if ( pos != Vector3.Zero )
+		{
+			Particles.MakeParticleSystem( "particles/physgun_freeze.vpcf", new Transform( pos ), 4 );
+		}
+	}
+}

--- a/Code/Components/UndoSystem/UndoSystem.cs
+++ b/Code/Components/UndoSystem/UndoSystem.cs
@@ -1,6 +1,5 @@
 using Sandbox;
 using Sandbox.Diagnostics;
-using Sandbox.Events;
 
 public sealed class UndoSystem : GameObjectSystem<UndoSystem>
 {

--- a/Code/GameObjectSystems/GameManager.Commands.cs
+++ b/Code/GameObjectSystems/GameManager.Commands.cs
@@ -71,6 +71,16 @@ public sealed partial class GameManager
 
 		go.NetworkSpawn( playerObject.Network.Owner );
 		go.Network.SetOrphanedMode( NetworkOrphaned.Host );
+
+		// Send undo event for spawning this prop
+		UndoSystem.Add(playerObject.GetComponent<Player>(), () => UndoSpawn(go) );
+	}
+
+	static string UndoSpawn(GameObject obj)
+	{
+		obj.Destroy();
+
+		return "Undone spawning of object";
 	}
 
 	static async Task<string> SpawnPackageModel( string packageName, GameObject source )

--- a/Code/GameObjectSystems/GameManager.cs
+++ b/Code/GameObjectSystems/GameManager.cs
@@ -27,6 +27,11 @@ public sealed partial class GameManager : GameObjectSystem<GameManager>, IPlayer
 		// Spawn this object and make the client the owner
 		var playerGo = GameObject.Clone( "/prefabs/player.prefab", new CloneConfig { Name = $"Player - {channel.DisplayName}", StartEnabled = true, Transform = startLocation } );
 		var player = playerGo.Components.Get<Player>( true );
+
+		player.Name = channel.Name;
+		player.SteamId = channel.SteamId;
+		player.PartyId = channel.PartyId;
+
 		playerGo.NetworkSpawn( channel );
 
 		IPlayerEvent.PostToGameObject( player.GameObject, x => x.OnSpawned() );

--- a/Code/MeshBuilders/VertexMeshBuilder.Cylinder.cs
+++ b/Code/MeshBuilders/VertexMeshBuilder.Cylinder.cs
@@ -145,6 +145,8 @@ namespace Sandbox
 			SceneTraceResult trace = pawn.Scene.Trace.Ray(eye.Position, eye.Position + eye.Forward * 5000.0f ).UseHitboxes().IgnoreGameObject(pawn).Run();
 			entity.WorldPosition = trace.EndPosition + trace.Normal;
 			// Event.Run( "entity.spawned", entity, ConsoleSystem.Caller.Pawn );
+
+			UndoSystem.Add( player, ReadyUndo( entity, "Cylinder" ) );
 		}
 	}
 }

--- a/Code/MeshBuilders/VertexMeshBuilder.Gear.cs
+++ b/Code/MeshBuilders/VertexMeshBuilder.Gear.cs
@@ -241,6 +241,8 @@ namespace Sandbox
 
 			entity.WorldPosition = trace.EndPosition + trace.Normal;
 			// Event.Run( "entity.spawned", entity, ConsoleSystem.Caller.Pawn );
+
+			UndoSystem.Add( player, ReadyUndo( entity, "Gear" ) );
 		}
 	}
 }

--- a/Code/MeshBuilders/VertexMeshBuilder.Sphere.cs
+++ b/Code/MeshBuilders/VertexMeshBuilder.Sphere.cs
@@ -112,6 +112,8 @@ namespace Sandbox
 
 			entity.WorldPosition = trace.EndPosition + trace.Normal;
 			// Event.Run( "entity.spawned", entity, ConsoleSystem.Caller.Pawn );
+
+			UndoSystem.Add( player, ReadyUndo( entity, "Sphere" ) );
 		}
 	}
 }

--- a/Code/MeshBuilders/VertexMeshBuilder.cs
+++ b/Code/MeshBuilders/VertexMeshBuilder.cs
@@ -61,6 +61,17 @@ namespace Sandbox
 
 			entity.WorldPosition = trace.EndPosition + trace.Normal;
 			// Event.Run( "entity.spawned", entity, ConsoleSystem.Caller.Pawn );
+
+			UndoSystem.Add( player, ReadyUndo( entity, "Plate" ) );
+		}
+
+		private static Func<string> ReadyUndo(GameObject obj, string shape)
+		{
+			return () =>
+			{
+				obj.Destroy();
+				return "Undone " + shape + " DynShape creation";
+			};
 		}
 
 		public static GameObject SpawnEntity( string modelId )

--- a/ProjectSettings/Input.config
+++ b/ProjectSettings/Input.config
@@ -1,194 +1,212 @@
 {
-  "Actions": [
-    {
-      "Name": "Forward",
-      "KeyboardCode": "W",
-      "GamepadCode": "None",
-      "GroupName": "Movement"
-    },
-    {
-      "Name": "Backward",
-      "KeyboardCode": "S",
-      "GamepadCode": "None",
-      "GroupName": "Movement"
-    },
-    {
-      "Name": "Left",
-      "KeyboardCode": "A",
-      "GamepadCode": "None",
-      "GroupName": "Movement"
-    },
-    {
-      "Name": "Right",
-      "KeyboardCode": "D",
-      "GamepadCode": "None",
-      "GroupName": "Movement"
-    },
-    {
-      "Name": "Jump",
-      "KeyboardCode": "space",
-      "GamepadCode": "A",
-      "GroupName": "Movement"
-    },
-    {
-      "Name": "Run",
-      "KeyboardCode": "shift",
-      "GamepadCode": "LeftJoystickButton",
-      "GroupName": "Movement"
-    },
-    {
-      "Name": "Walk",
-      "KeyboardCode": "alt",
-      "GamepadCode": "None",
-      "GroupName": "Movement"
-    },
-    {
-      "Name": "Duck",
-      "KeyboardCode": "ctrl",
-      "GamepadCode": "B",
-      "GroupName": "Movement"
-    },
-    {
-      "Name": "attack1",
-      "KeyboardCode": "mouse1",
-      "GamepadCode": "RightTrigger",
-      "GroupName": "Actions"
-    },
-    {
-      "Name": "attack2",
-      "KeyboardCode": "mouse2",
-      "GamepadCode": "LeftTrigger",
-      "GroupName": "Actions"
-    },
-    {
-      "Name": "reload",
-      "KeyboardCode": "r",
-      "GamepadCode": "X",
-      "GroupName": "Actions"
-    },
-    {
-      "Name": "use",
-      "KeyboardCode": "e",
-      "GamepadCode": "Y",
-      "GroupName": "Actions"
-    },
-    {
-      "Name": "Slot1",
-      "KeyboardCode": "1",
-      "GamepadCode": "DpadWest",
-      "GroupName": "Inventory"
-    },
-    {
-      "Name": "Slot2",
-      "KeyboardCode": "2",
-      "GamepadCode": "DpadEast",
-      "GroupName": "Inventory"
-    },
-    {
-      "Name": "Slot3",
-      "KeyboardCode": "3",
-      "GamepadCode": "DpadSouth",
-      "GroupName": "Inventory"
-    },
-    {
-      "Name": "Slot4",
-      "KeyboardCode": "4",
-      "GamepadCode": "None",
-      "GroupName": "Inventory"
-    },
-    {
-      "Name": "Slot5",
-      "KeyboardCode": "5",
-      "GamepadCode": "None",
-      "GroupName": "Inventory"
-    },
-    {
-      "Name": "Slot6",
-      "KeyboardCode": "6",
-      "GamepadCode": "None",
-      "GroupName": "Inventory"
-    },
-    {
-      "Name": "Slot7",
-      "KeyboardCode": "7",
-      "GamepadCode": "None",
-      "GroupName": "Inventory"
-    },
-    {
-      "Name": "Slot8",
-      "KeyboardCode": "8",
-      "GamepadCode": "None",
-      "GroupName": "Inventory"
-    },
-    {
-      "Name": "Slot9",
-      "KeyboardCode": "9",
-      "GamepadCode": "None",
-      "GroupName": "Inventory"
-    },
-    {
-      "Name": "SlotPrev",
-      "KeyboardCode": "mouse4",
-      "GamepadCode": "SwitchLeftBumper",
-      "GroupName": "Inventory"
-    },
-    {
-      "Name": "SlotNext",
-      "KeyboardCode": "mouse5",
-      "GamepadCode": "SwitchRightBumper",
-      "GroupName": "Inventory"
-    },
-    {
-      "Name": "View",
-      "KeyboardCode": "C",
-      "GamepadCode": "RightJoystickButton",
-      "GroupName": "Other"
-    },
-    {
-      "Name": "Voice",
-      "KeyboardCode": "v",
-      "GamepadCode": "None",
-      "GroupName": "Other"
-    },
-    {
-      "Name": "Drop",
-      "KeyboardCode": "g",
-      "GamepadCode": "None",
-      "GroupName": "Other"
-    },
-    {
-      "Name": "Flashlight",
-      "KeyboardCode": "f",
-      "GamepadCode": "DpadNorth",
-      "GroupName": "Other"
-    },
-    {
-      "Name": "Score",
-      "KeyboardCode": "tab",
-      "GamepadCode": "SwitchLeftMenu",
-      "GroupName": "Other"
-    },
-    {
-      "Name": "Menu",
-      "KeyboardCode": "Q",
-      "GamepadCode": "SwitchRightMenu",
-      "GroupName": "Other"
-    },
-    {
-      "Name": "Chat",
-      "KeyboardCode": "enter",
-      "GamepadCode": "None",
-      "GroupName": "Other"
-    },
-    {
-      "Name": "Noclip",
-      "KeyboardCode": "N",
-      "GamepadCode": "None",
-      "GroupName": "Movement"
-    }
-  ],
-  "__guid": "e03b8140-d134-43a0-9eac-a7758ecbf3c7",
-  "__schema": "configdata",
-  "__type": "InputSettings",
-  "__version": 1
+	"Actions": [
+		{
+			"Name": "Forward",
+			"KeyboardCode": "W",
+			"GamepadCode": "None",
+			"GroupName": "Movement"
+		},
+		{
+			"Name": "Backward",
+			"KeyboardCode": "S",
+			"GamepadCode": "None",
+			"GroupName": "Movement"
+		},
+		{
+			"Name": "Left",
+			"KeyboardCode": "A",
+			"GamepadCode": "None",
+			"GroupName": "Movement"
+		},
+		{
+			"Name": "Right",
+			"KeyboardCode": "D",
+			"GamepadCode": "None",
+			"GroupName": "Movement"
+		},
+		{
+			"Name": "Jump",
+			"KeyboardCode": "space",
+			"GamepadCode": "A",
+			"GroupName": "Movement"
+		},
+		{
+			"Name": "Run",
+			"KeyboardCode": "shift",
+			"GamepadCode": "LeftJoystickButton",
+			"GroupName": "Movement"
+		},
+		{
+			"Name": "Walk",
+			"KeyboardCode": "alt",
+			"GamepadCode": "None",
+			"GroupName": "Movement"
+		},
+		{
+			"Name": "Duck",
+			"KeyboardCode": "ctrl",
+			"GamepadCode": "B",
+			"GroupName": "Movement"
+		},
+		{
+			"Name": "attack1",
+			"KeyboardCode": "mouse1",
+			"GamepadCode": "RightTrigger",
+			"GroupName": "Actions"
+		},
+		{
+			"Name": "attack2",
+			"KeyboardCode": "mouse2",
+			"GamepadCode": "LeftTrigger",
+			"GroupName": "Actions"
+		},
+		{
+			"Name": "reload",
+			"KeyboardCode": "r",
+			"GamepadCode": "X",
+			"GroupName": "Actions"
+		},
+		{
+			"Name": "use",
+			"KeyboardCode": "e",
+			"GamepadCode": "Y",
+			"GroupName": "Actions"
+		},
+		{
+			"Name": "Slot1",
+			"KeyboardCode": "1",
+			"GamepadCode": "DpadWest",
+			"GroupName": "Inventory"
+		},
+		{
+			"Name": "Slot2",
+			"KeyboardCode": "2",
+			"GamepadCode": "DpadEast",
+			"GroupName": "Inventory"
+		},
+		{
+			"Name": "Slot3",
+			"KeyboardCode": "3",
+			"GamepadCode": "DpadSouth",
+			"GroupName": "Inventory"
+		},
+		{
+			"Name": "Slot4",
+			"KeyboardCode": "4",
+			"GamepadCode": "None",
+			"GroupName": "Inventory"
+		},
+		{
+			"Name": "Slot5",
+			"KeyboardCode": "5",
+			"GamepadCode": "None",
+			"GroupName": "Inventory"
+		},
+		{
+			"Name": "Slot6",
+			"KeyboardCode": "6",
+			"GamepadCode": "None",
+			"GroupName": "Inventory"
+		},
+		{
+			"Name": "Slot7",
+			"KeyboardCode": "7",
+			"GamepadCode": "None",
+			"GroupName": "Inventory"
+		},
+		{
+			"Name": "Slot8",
+			"KeyboardCode": "8",
+			"GamepadCode": "None",
+			"GroupName": "Inventory"
+		},
+		{
+			"Name": "Slot9",
+			"KeyboardCode": "9",
+			"GamepadCode": "None",
+			"GroupName": "Inventory"
+		},
+		{
+			"Name": "SlotPrev",
+			"KeyboardCode": "mouse4",
+			"GamepadCode": "SwitchLeftBumper",
+			"GroupName": "Inventory"
+		},
+		{
+			"Name": "SlotNext",
+			"KeyboardCode": "mouse5",
+			"GamepadCode": "SwitchRightBumper",
+			"GroupName": "Inventory"
+		},
+		{
+			"Name": "View",
+			"KeyboardCode": "C",
+			"GamepadCode": "RightJoystickButton",
+			"GroupName": "Other"
+		},
+		{
+			"Name": "Voice",
+			"KeyboardCode": "v",
+			"GamepadCode": "None",
+			"GroupName": "Other"
+		},
+		{
+			"Name": "Drop",
+			"KeyboardCode": "g",
+			"GamepadCode": "None",
+			"GroupName": "Other"
+		},
+		{
+			"Name": "Flashlight",
+			"KeyboardCode": "f",
+			"GamepadCode": "DpadNorth",
+			"GroupName": "Other"
+		},
+		{
+			"Name": "Score",
+			"KeyboardCode": "tab",
+			"GamepadCode": "SwitchLeftMenu",
+			"GroupName": "Other"
+		},
+		{
+			"Name": "Menu",
+			"KeyboardCode": "Q",
+			"GamepadCode": "SwitchRightMenu",
+			"GroupName": "Other"
+		},
+		{
+			"Name": "Chat",
+			"KeyboardCode": "enter",
+			"GamepadCode": "None",
+			"GroupName": "Other"
+		},
+		{
+			"Name": "Noclip",
+			"KeyboardCode": "N",
+			"GamepadCode": "None",
+			"GroupName": "Movement"
+		},
+		{
+			"Name": "Noclip",
+			"KeyboardCode": "N",
+			"GamepadCode": "None",
+			"GroupName": "Movement"
+		},
+		{
+			"Name": "Undo",
+			"KeyboardCode": "Z",
+			"GamepadCode": "None",
+			"GroupName": "Other"
+		},
+		{
+			"Name": "Redo",
+			"KeyboardCode": "Y",
+			"GamepadCode": "None",
+			"GroupName": "Other"
+		}
+	],
+	"__guid": "e03b8140-d134-43a0-9eac-a7758ecbf3c7",
+	"__schema": "configdata",
+	"__type": "InputSettings",
+	"__version": 1
 }


### PR DESCRIPTION
Have recreated the Undo system from the old code. Works for:
* Props
* DynShapes
* Wheel (but it currently doesn't remove the extra GameObject on the parent)
* Weld

Redo functionality is a TODO.
 
A couple of other small (related) changes:
* Weld tool secondary (Unweld all) moved to Reload
* Added SteamId, GroupId, and User Name to 'Player' class