### PR TITLE
Add ability to hide crosshairs on weapons

### DIFF
--- a/Code/Components/Base/BaseWeapon.cs
+++ b/Code/Components/Base/BaseWeapon.cs
@@ -32,6 +32,11 @@ public partial class BaseWeapon : Component
 		return LocalWorldModel?.GetAttachment( name ) ?? WorldTransform;
 	}
 
+	public virtual bool ShouldShowCrosshair()
+	{
+		return true;
+	}
+
 	protected override void OnAwake()
 	{
 		var obj = Owner?.Controller?.Renderer?.GetBoneObject( ParentBone );

--- a/Code/Components/Weapons/Fists.cs
+++ b/Code/Components/Weapons/Fists.cs
@@ -1,6 +1,11 @@
 ﻿[Spawnable, Library( "weapon_fists" )]
 partial class Fists : BaseWeapon
 {
+	public override bool ShouldShowCrosshair()
+	{
+		return false;
+	}
+
 	public override bool CanReload()
 	{
 		return false;

--- a/Code/Components/Weapons/Flashlight.cs
+++ b/Code/Components/Weapons/Flashlight.cs
@@ -7,6 +7,10 @@ partial class Flashlight : BaseWeapon
 	[Sync, Change( nameof( ToggleLight ) )] private bool LightEnabled { get; set; } = true;
 
 	TimeSince timeSinceLightToggled;
+	public override bool ShouldShowCrosshair()
+	{
+		return false;
+	}
 
 	public override void OnControl()
 	{

--- a/Code/UI/Hud/Components/Crosshair.razor
+++ b/Code/UI/Hud/Components/Crosshair.razor
@@ -18,8 +18,6 @@
         var weapon = GetCurrentWeapon();
         bool active = (weapon != null) ? weapon.ShouldShowCrosshair() : true;
 
-        Log.Info(weapon + " " + weapon.ShouldShowCrosshair() + " " + active );
-
         SetClass("active", active);
     }
 

--- a/Code/UI/Hud/Components/Crosshair.razor
+++ b/Code/UI/Hud/Components/Crosshair.razor
@@ -12,4 +12,25 @@
     {
         Current = this;
     }
+    
+    public override void Tick()
+    {
+        var weapon = GetCurrentWeapon();
+        bool active = (weapon != null) ? weapon.ShouldShowCrosshair() : true;
+
+        Log.Info(weapon + " " + weapon.ShouldShowCrosshair() + " " + active );
+
+        SetClass("active", active);
+    }
+
+    public static BaseWeapon GetCurrentWeapon()
+    {
+        var player = Player.FindLocalPlayer();
+        if (player == null) return null;
+
+        var inventory = player.Inventory;
+        if (inventory == null) return null;
+
+        return inventory.ActiveWeapon;
+    }
 }

--- a/Code/UI/Hud/Components/Crosshair.razor.scss
+++ b/Code/UI/Hud/Components/Crosshair.razor.scss
@@ -10,4 +10,9 @@
     left: 50%;
     border-radius: 100px;
     transform: translate( -50% -50% );
+    opacity: 0.0;
+
+    &.active {
+        opacity: 1.0;
+    }
 }


### PR DESCRIPTION
Done via overriding 'shouldShowCrosshair()' in the weapon. By default the base weapon just returns true.
Closes #32 