### PR TITLE
Fix dynshapes placement

### DIFF
--- a/Code/Components/Player/Player.cs
+++ b/Code/Components/Player/Player.cs
@@ -158,17 +158,34 @@ public sealed partial class Player : Component, Component.IDamageable, SandboxPl
 		IPlayerEvent.PostToGameObject( GameObject, x => x.OnLand( distance, impactVelocity ) );
 	}
 
-	public static SceneTraceResult DoBasicTrace()
+	/// <summary>
+	/// Function that runs a trace from the Player's eye forwards.
+	/// 
+	/// Use this is you already have a copy of the Player.
+	/// </summary>
+	/// <returns></returns>
+	public SceneTraceResult BasicTrace()
 	{
-		var player = Player.FindLocalPlayer();
-		var trace = player.Scene.Trace.Ray( player.AimRay.Position, player.AimRay.Position + player.AimRay.Forward * 5000 )
+		var trace = Scene.Trace.Ray( AimRay.Position, AimRay.Position + AimRay.Forward * 5000 )
 				.UseHitboxes()
 				.WithAnyTags( "solid", "npc", "glass" )
 				.WithoutTags( "debris", "player" )
-				.IgnoreGameObjectHierarchy( player.GameObject )
+				.IgnoreGameObjectHierarchy( GameObject )
 				.Size( 2 );
 
 		return trace.Run();
+	}
+
+	/// <summary>
+	/// Static function that gets the Local Player, and runs a trace from it's eye forwards.
+	/// 
+	/// Use this if you don't have a copy of the Player
+	/// </summary>
+	/// <returns>SceneTraceResult of a straight trace from the player's eye forwards</returns>
+	public static SceneTraceResult DoBasicTrace()
+	{
+		var player = Player.FindLocalPlayer();
+		return player.BasicTrace();
 	}
 
 	public static Player FindPlayerByConnection( Connection connection )

--- a/Code/MeshBuilders/VertexMeshBuilder.Cylinder.cs
+++ b/Code/MeshBuilders/VertexMeshBuilder.Cylinder.cs
@@ -139,10 +139,10 @@ namespace Sandbox
 			var modelId = CreateCylinder(radius, depth, numFaces, texScale);
 			
 			var entity = SpawnEntity( modelId );
+
 			Player player = Player.FindLocalPlayer();
-			GameObject pawn = player.Controller.GameObject;
-			Transform eye = player.EyeTransform;
-			SceneTraceResult trace = pawn.Scene.Trace.Ray(eye.Position, eye.Position + eye.Forward * 5000.0f ).UseHitboxes().IgnoreGameObject(pawn).Run();
+			SceneTraceResult trace = player.BasicTrace();
+
 			entity.WorldPosition = trace.EndPosition + trace.Normal;
 
 			UndoSystem.Add( creator: player, callback: ReadyUndo( entity, "Cylinder" ), prop: entity );

--- a/Code/MeshBuilders/VertexMeshBuilder.Gear.cs
+++ b/Code/MeshBuilders/VertexMeshBuilder.Gear.cs
@@ -234,10 +234,9 @@ namespace Sandbox
 		{
 			var modelId = CreateGear( radius, depth, numTeeth, cutDepth, cutAngle, texScale );
 			var entity = SpawnEntity( modelId );
+
 			Player player = Player.FindLocalPlayer();
-			GameObject pawn = player.Controller.GameObject;
-			Transform eye = player.EyeTransform;
-			SceneTraceResult trace = pawn.Scene.Trace.Ray(eye.Position, eye.Position + eye.Forward * 5000.0f ).UseHitboxes().IgnoreGameObject(pawn).Run();
+			SceneTraceResult trace = player.BasicTrace();
 
 			entity.WorldPosition = trace.EndPosition + trace.Normal;
 

--- a/Code/MeshBuilders/VertexMeshBuilder.Sphere.cs
+++ b/Code/MeshBuilders/VertexMeshBuilder.Sphere.cs
@@ -105,12 +105,11 @@ namespace Sandbox
 			var modelId = CreateSphere(radius, numSegments, texSize);
 			
 			var entity = SpawnEntity( modelId );
-			Player player = Player.FindLocalPlayer();
-			GameObject pawn = player.Controller.GameObject;
-			Transform eye = player.EyeTransform;
-			SceneTraceResult trace = pawn.Scene.Trace.Ray(eye.Position, eye.Position + eye.Forward * 5000.0f ).UseHitboxes().IgnoreGameObject(pawn).Run();
 
-			entity.WorldPosition = trace.EndPosition + trace.Normal;
+			Player player = Player.FindLocalPlayer();
+			SceneTraceResult trace = player.BasicTrace();
+
+			entity.WorldPosition = trace.EndPosition + trace.Normal + new Vector3(0, 0, radius);
 
 			UndoSystem.Add( creator: player, callback: ReadyUndo( entity, "Sphere" ), prop: entity );
 		}

--- a/Code/MeshBuilders/VertexMeshBuilder.cs
+++ b/Code/MeshBuilders/VertexMeshBuilder.cs
@@ -54,10 +54,9 @@ namespace Sandbox
 		{
 			var modelId = CreateRectangle( length, width, height, texSize );
 			var entity = SpawnEntity( modelId );
+
 			Player player = Player.FindLocalPlayer();
-			GameObject pawn = player.Controller.GameObject;
-			Transform eye = player.EyeTransform;
-			SceneTraceResult trace = pawn.Scene.Trace.Ray(eye.Position, eye.Position + eye.Forward * 5000.0f ).UseHitboxes().IgnoreGameObject(pawn).Run();
+			SceneTraceResult trace = player.BasicTrace();
 
 			entity.WorldPosition = trace.EndPosition + trace.Normal;
 


### PR DESCRIPTION
Dynshapes weren't using the standard trace we have setup, which I think means it was colliding with something about the player - likely the phys/toolgun.

Swapped to the player trace. Closes #67.

Note:
I created a new Trace function for the instanced Player object, and just made the Static function get the player and then call that.
This will be helpful for situations where you already have the player object.

Also, some LFS shenanigans?