### PR TITLE
Fix spawned props rendering incorrectly and having no name

### DIFF
--- a/Code/GameObjectSystems/SandboxGameManager.Commands.cs
+++ b/Code/GameObjectSystems/SandboxGameManager.Commands.cs
@@ -36,12 +36,9 @@ public partial class SandboxGameManager
 		if ( model == null || model.IsError )
 			return;
 
-		var go = new GameObject
-		{
-			WorldPosition = endPos + Vector3.Down * model.PhysicsBounds.Mins.z,
-			WorldRotation = modelRotation,
-			Tags = { "solid" }
-		};
+		var go = new GameObject(false, $"Prop ({modelname})");
+		go.Tags.Add("solid", "removable");
+		go.WorldTransform = new Transform(endPos + Vector3.Down * model.PhysicsBounds.Mins.z, modelRotation);
 
 		var prop = go.AddComponent<Prop>();
 		prop.Model = model;
@@ -52,7 +49,7 @@ public partial class SandboxGameManager
 		}
 
 		var propHelper = go.AddComponent<PropHelper>();
-
+		
 		var rb = propHelper.Rigidbody;
 		if ( rb.IsValid() )
 		{
@@ -61,13 +58,13 @@ public partial class SandboxGameManager
 			{
 				if ( !shape.IsMeshShape )
 					continue;
-
+		
 				var newCollider = go.AddComponent<BoxCollider>();
 				newCollider.Scale = model.PhysicsBounds.Size;
 			}
 		}
 
-		go.NetworkSpawn( playerObject.Network.Owner );
+		go.NetworkSpawn( true, playerObject.Network.Owner );
 		go.Network.SetOrphanedMode( NetworkOrphaned.Host );
 		IPropSpawnedEvent.Post( x => x.OnSpawned( prop ) );
 


### PR DESCRIPTION
Enabling the game object too early was causing weird rendering issues with transparent props. This matches the base sandbox behavior of only enabling the game object after it is fully configured.

Before:
<img width="1544" height="934" alt="image" src="https://github.com/user-attachments/assets/8eeff248-202a-4804-851d-9084c7c81a81" />

After:
<img width="1688" height="843" alt="image" src="https://github.com/user-attachments/assets/6dc91902-e763-4237-9266-e30037af3948" />

While I was here I also added a name to the game objects so it is easier to tell them apart in the hierarchy.
<img width="709" height="129" alt="image" src="https://github.com/user-attachments/assets/f5724c90-ee18-4988-bcea-be12b5fc642e" />
