### PR TITLE
fixed physgun effects

### DIFF
--- a/Assets/materials/weapons/v_toolgun/screen.vmat.meta
+++ b/Assets/materials/weapons/v_toolgun/screen.vmat.meta
@@ -1,0 +1,23 @@
+{
+  "publish": {
+    "Enabled": false,
+    "ProjectConfig": {
+      "Title": "Screen",
+      "Type": "material",
+      "Org": "local",
+      "Ident": "screen",
+      "Schema": 0,
+      "IncludeSourceFiles": false,
+      "Resources": null,
+      "PackageReferences": null,
+      "EditorReferences": [
+        "facepunch.v_mp5#103131"
+      ],
+      "Mounts": null,
+      "IsStandaloneOnly": false,
+      "Metadata": {
+        "SingleAssetSource": "materials/weapons/v_toolgun/screen.vmat"
+      }
+    }
+  }
+}

--- a/Assets/materials/weapons/v_toolgun/toolgun.vmat.meta
+++ b/Assets/materials/weapons/v_toolgun/toolgun.vmat.meta
@@ -1,0 +1,23 @@
+{
+  "publish": {
+    "Enabled": false,
+    "ProjectConfig": {
+      "Title": "Toolgun",
+      "Type": "material",
+      "Org": "local",
+      "Ident": "toolgun",
+      "Schema": 0,
+      "IncludeSourceFiles": false,
+      "Resources": null,
+      "PackageReferences": null,
+      "EditorReferences": [
+        "facepunch.v_mp5#103131"
+      ],
+      "Mounts": null,
+      "IsStandaloneOnly": false,
+      "Metadata": {
+        "SingleAssetSource": "materials/weapons/v_toolgun/toolgun.vmat"
+      }
+    }
+  }
+}

--- a/Assets/materials/weapons/v_toolgun/toolgun2.vmat.meta
+++ b/Assets/materials/weapons/v_toolgun/toolgun2.vmat.meta
@@ -1,0 +1,23 @@
+{
+  "publish": {
+    "Enabled": false,
+    "ProjectConfig": {
+      "Title": "Toolgun 2",
+      "Type": "material",
+      "Org": "local",
+      "Ident": "toolgun2",
+      "Schema": 0,
+      "IncludeSourceFiles": false,
+      "Resources": null,
+      "PackageReferences": null,
+      "EditorReferences": [
+        "facepunch.v_mp5#103131"
+      ],
+      "Mounts": null,
+      "IsStandaloneOnly": false,
+      "Metadata": {
+        "SingleAssetSource": "materials/weapons/v_toolgun/toolgun2.vmat"
+      }
+    }
+  }
+}

--- a/Assets/materials/weapons/v_toolgun/toolgun3.vmat.meta
+++ b/Assets/materials/weapons/v_toolgun/toolgun3.vmat.meta
@@ -1,0 +1,23 @@
+{
+  "publish": {
+    "Enabled": false,
+    "ProjectConfig": {
+      "Title": "Toolgun 3",
+      "Type": "material",
+      "Org": "local",
+      "Ident": "toolgun3",
+      "Schema": 0,
+      "IncludeSourceFiles": false,
+      "Resources": null,
+      "PackageReferences": null,
+      "EditorReferences": [
+        "facepunch.v_mp5#103131"
+      ],
+      "Mounts": null,
+      "IsStandaloneOnly": false,
+      "Metadata": {
+        "SingleAssetSource": "materials/weapons/v_toolgun/toolgun3.vmat"
+      }
+    }
+  }
+}

--- a/Assets/prefabs/weapons/physgun/effects/beam-end.prefab
+++ b/Assets/prefabs/weapons/physgun/effects/beam-end.prefab
@@ -1,0 +1,780 @@
+{
+  "RootObject": {
+    "__guid": "e5cf5f34-17b5-4e70-b8db-d7f54a8ad61d",
+    "__version": 1,
+    "Flags": 0,
+    "Name": "beam-end",
+    "Position": "0,0,0",
+    "Rotation": "0,0,0,1",
+    "Scale": "1,1,1",
+    "Tags": "",
+    "Enabled": true,
+    "NetworkMode": 2,
+    "NetworkInterpolation": true,
+    "NetworkOrphaned": 0,
+    "OwnerTransfer": 1,
+    "Components": [
+      {
+        "__type": "TemporaryEffect",
+        "__guid": "efd434b8-3b7f-4dbf-be75-086c2abd0203",
+        "__enabled": true,
+        "DestroyAfterSeconds": 1,
+        "OnComponentDestroy": null,
+        "OnComponentDisabled": null,
+        "OnComponentEnabled": null,
+        "OnComponentFixedUpdate": null,
+        "OnComponentStart": null,
+        "OnComponentUpdate": null,
+        "WaitForChildEffects": true
+      }
+    ],
+    "Children": [
+      {
+        "__guid": "f5fa9957-6f01-45ad-b1bb-ac9b55b05bb9",
+        "__version": 1,
+        "Flags": 0,
+        "Name": "Spray",
+        "Position": "3.417858,-0.0000003237589,0",
+        "Rotation": "0,0,0,1",
+        "Scale": "1,1,1",
+        "Tags": "particles",
+        "Enabled": true,
+        "NetworkMode": 2,
+        "NetworkInterpolation": true,
+        "NetworkOrphaned": 0,
+        "OwnerTransfer": 1,
+        "Components": [
+          {
+            "__type": "Sandbox.ParticleEffect",
+            "__guid": "145ca6ef-bcd8-4c7e-b386-2e45b2c1db7c",
+            "__enabled": true,
+            "__version": 3,
+            "Alpha": {
+              "Type": "Curve",
+              "Evaluation": "Life",
+              "CurveA": [
+                {
+                  "x": 0,
+                  "y": 1,
+                  "in": 0,
+                  "out": 0,
+                  "mode": "Mirrored"
+                },
+                {
+                  "x": 0.48029557,
+                  "y": 1,
+                  "in": 1.5365853,
+                  "out": -1.5365853,
+                  "mode": "Mirrored"
+                },
+                {
+                  "x": 1,
+                  "y": 0,
+                  "in": 1.312303,
+                  "out": -1.312303,
+                  "mode": "Mirrored"
+                }
+              ],
+              "CurveB": [
+                {
+                  "x": 0.5,
+                  "y": 0.5,
+                  "in": 0,
+                  "out": 0,
+                  "mode": "Mirrored"
+                }
+              ]
+            },
+            "ApplyAlpha": true,
+            "ApplyColor": true,
+            "ApplyRotation": false,
+            "ApplyShape": true,
+            "Bounce": 0.3,
+            "Brightness": {
+              "Type": "Curve",
+              "Evaluation": "Life",
+              "CurveA": {
+                "rangey": "0,100",
+                "frames": [
+                  {
+                    "x": 0,
+                    "y": 1,
+                    "in": 2.625,
+                    "out": -2.625,
+                    "mode": "Mirrored"
+                  },
+                  {
+                    "x": 1,
+                    "y": 0,
+                    "in": 0.022727339,
+                    "out": -0.022727339,
+                    "mode": "Mirrored"
+                  }
+                ]
+              },
+              "CurveB": [
+                {
+                  "x": 0.5,
+                  "y": 0.5,
+                  "in": 0,
+                  "out": 0,
+                  "mode": "Mirrored"
+                }
+              ]
+            },
+            "Bumpiness": 0,
+            "Collision": false,
+            "CollisionIgnore": null,
+            "CollisionPrefab": null,
+            "CollisionPrefabAlign": false,
+            "CollisionPrefabChance": 1,
+            "CollisionPrefabRotation": 0,
+            "CollisionRadius": 1,
+            "ConstantMovement": {
+              "X": 0,
+              "Y": 0,
+              "Z": 0
+            },
+            "Damping": 5,
+            "DieOnCollisionChance": 0.3,
+            "FollowerPrefab": null,
+            "FollowerPrefabChance": 1,
+            "FollowerPrefabKill": true,
+            "Force": true,
+            "ForceDirection": "0,0,-200",
+            "ForceScale": 1,
+            "ForceSpace": "World",
+            "Friction": 0.2,
+            "Gradient": {
+              "Type": "Range",
+              "Evaluation": "Particle",
+              "GradientA": {
+                "blend": "Linear",
+                "color": [
+                  {
+                    "t": 0.5,
+                    "c": "1,1,1,1"
+                  }
+                ],
+                "alpha": []
+              },
+              "GradientB": {
+                "blend": "Linear",
+                "color": [
+                  {
+                    "t": 0.5,
+                    "c": "1,1,1,1"
+                  }
+                ],
+                "alpha": []
+              },
+              "ConstantA": "0.8132,0.94949,0.97674,1",
+              "ConstantB": "0.2,0.6,1,1"
+            },
+            "InitialVelocity": {
+              "X": 0,
+              "Y": 0,
+              "Z": 0
+            },
+            "Lifetime": {
+              "Type": "Range",
+              "Evaluation": "Seed",
+              "Constants": "0.2,0.4,0,0"
+            },
+            "LocalSpace": {
+              "Type": "Curve",
+              "Evaluation": "Life",
+              "CurveA": {
+                "rangex": "0,0.4234375",
+                "frames": [
+                  {
+                    "x": 0,
+                    "y": 1,
+                    "in": 2.4038465,
+                    "out": -2.4038465,
+                    "mode": "Mirrored"
+                  },
+                  {
+                    "x": 1,
+                    "y": 0,
+                    "in": 0,
+                    "out": 0,
+                    "mode": "Mirrored"
+                  }
+                ]
+              },
+              "CurveB": [
+                {
+                  "x": 0.5,
+                  "y": 0.5,
+                  "in": 0,
+                  "out": 0,
+                  "mode": "Mirrored"
+                }
+              ]
+            },
+            "MaxParticles": 5000,
+            "OnComponentDestroy": null,
+            "OnComponentDisabled": null,
+            "OnComponentEnabled": null,
+            "OnComponentFixedUpdate": null,
+            "OnComponentStart": null,
+            "OnComponentUpdate": null,
+            "OnParticleCreated": null,
+            "OnParticleDestroyed": null,
+            "OrbitalForce": {
+              "X": 0,
+              "Y": 0,
+              "Z": 0
+            },
+            "OrbitalPull": 0,
+            "PerParticleTimeScale": 1,
+            "Pitch": 0,
+            "PreWarm": 0,
+            "PushStrength": 0,
+            "Roll": 0,
+            "Scale": {
+              "Type": "CurveRange",
+              "Evaluation": "Life",
+              "CurveA": {
+                "rangey": "0,6",
+                "frames": [
+                  {
+                    "x": 0,
+                    "y": 0.185484,
+                    "in": 7.7882873E-07,
+                    "out": -7.7882873E-07,
+                    "mode": "Mirrored"
+                  },
+                  {
+                    "x": 0.1880109,
+                    "y": 0.07718992,
+                    "in": 0,
+                    "out": 0,
+                    "mode": "Mirrored"
+                  },
+                  {
+                    "x": 1,
+                    "y": 0,
+                    "in": 0,
+                    "out": 0,
+                    "mode": "Mirrored"
+                  }
+                ]
+              },
+              "CurveB": {
+                "rangey": "0,4",
+                "frames": [
+                  {
+                    "x": 0,
+                    "y": 0.05645162,
+                    "in": 0.35714334,
+                    "out": -0.35714334,
+                    "mode": "Mirrored"
+                  },
+                  {
+                    "x": 0.1893733,
+                    "y": 0.03729546,
+                    "in": 0,
+                    "out": 0,
+                    "mode": "Mirrored"
+                  },
+                  {
+                    "x": 1,
+                    "y": 0,
+                    "in": 0,
+                    "out": 0,
+                    "mode": "Mirrored"
+                  }
+                ]
+              }
+            },
+            "SequenceId": 0,
+            "SequenceSpeed": 1,
+            "SequenceTime": 1,
+            "SheetSequence": false,
+            "StartDelay": 0,
+            "StartVelocity": {
+              "Type": "Range",
+              "Evaluation": "Seed",
+              "Constants": "100,200,0,0"
+            },
+            "Stretch": 0,
+            "TimeScale": 1,
+            "Timing": "GameTime",
+            "Tint": "1,1,1,1",
+            "UsePrefabFeature": false,
+            "Yaw": {
+              "Type": "Range",
+              "Evaluation": "Seed",
+              "Constants": "0,360,0,0"
+            }
+          },
+          {
+            "__type": "Sandbox.ParticleSpriteRenderer",
+            "__guid": "6da70c3b-62cc-49ed-83b2-c21df7177e9d",
+            "__enabled": true,
+            "Additive": true,
+            "Alignment": "LookAtCamera",
+            "BlurAmount": 1,
+            "BlurOpacity": 1,
+            "BlurSpacing": 1,
+            "DepthFeather": 0,
+            "FaceVelocity": false,
+            "FogStrength": 1,
+            "LeadingTrail": true,
+            "Lighting": false,
+            "MotionBlur": true,
+            "OnComponentDestroy": null,
+            "OnComponentDisabled": null,
+            "OnComponentEnabled": null,
+            "OnComponentFixedUpdate": null,
+            "OnComponentStart": null,
+            "OnComponentUpdate": null,
+            "Opaque": false,
+            "Pivot": "0.51,0",
+            "RenderOptions": {
+              "GameLayer": true,
+              "OverlayLayer": false,
+              "BloomLayer": true,
+              "AfterUILayer": false
+            },
+            "RotationOffset": 0,
+            "Scale": 1.1143552,
+            "Shadows": false,
+            "SortMode": "Unsorted",
+            "Texture": {
+              "$compiler": "texture",
+              "$source": "imagefile",
+              "data": {
+                "FilePath": "textures/shapes/triangle1.png",
+                "MaxSize": 4096,
+                "ConvertHeightToNormals": false,
+                "NormalScale": 1,
+                "Rotate": 0,
+                "FlipVertical": false,
+                "FlipHorizontal": false,
+                "Cropping": {
+                  "Left": 0,
+                  "Top": 0,
+                  "Right": 0,
+                  "Bottom": 0
+                },
+                "Padding": {
+                  "Left": 0,
+                  "Top": 0,
+                  "Right": 0,
+                  "Bottom": 0
+                },
+                "InvertColor": false,
+                "Tint": "1,1,1,1",
+                "Blur": 0,
+                "Sharpen": 0,
+                "Brightness": 1,
+                "Contrast": 1,
+                "Saturation": 1,
+                "Hue": 0,
+                "Colorize": false,
+                "TargetColor": "0,1,0,1",
+                "CacheToDisk": true
+              },
+              "compiled": null
+            },
+            "TextureFilter": "Bilinear"
+          },
+          {
+            "__type": "Sandbox.ParticleConeEmitter",
+            "__guid": "580ca3a6-9187-48fd-9cd5-a8984ebebddd",
+            "__enabled": true,
+            "Burst": 0,
+            "CenterBias": 1,
+            "CenterBiasVelocity": 1,
+            "ConeAngle": 80,
+            "ConeFar": 1,
+            "ConeNear": 1,
+            "Delay": 0,
+            "DestroyOnEnd": false,
+            "Duration": 1,
+            "InVolume": false,
+            "Loop": true,
+            "OnComponentDestroy": null,
+            "OnComponentDisabled": null,
+            "OnComponentEnabled": null,
+            "OnComponentFixedUpdate": null,
+            "OnComponentStart": null,
+            "OnComponentUpdate": null,
+            "OnEdge": false,
+            "Rate": 100,
+            "RateOverDistance": 0,
+            "VelocityMultiplier": 1,
+            "VelocityRandom": 0.2
+          },
+          {
+            "__type": "Sandbox.ParticleLightRenderer",
+            "__guid": "e8209ae1-f2be-494c-a3e0-adf585d95f67",
+            "__enabled": true,
+            "Attenuation": 1,
+            "Brightness": 0.2,
+            "CastShadows": false,
+            "LightColor": {
+              "Type": "Constant",
+              "Evaluation": "Life",
+              "GradientA": {
+                "blend": "Linear",
+                "color": [
+                  {
+                    "t": 0.5,
+                    "c": "1,1,1,1"
+                  }
+                ],
+                "alpha": []
+              },
+              "GradientB": {
+                "blend": "Linear",
+                "color": [
+                  {
+                    "t": 0.5,
+                    "c": "1,1,1,1"
+                  }
+                ],
+                "alpha": []
+              },
+              "ConstantA": "1,1,1,1",
+              "ConstantB": "1,1,1,1"
+            },
+            "MaximumLights": 8,
+            "OnComponentDestroy": null,
+            "OnComponentDisabled": null,
+            "OnComponentEnabled": null,
+            "OnComponentFixedUpdate": null,
+            "OnComponentStart": null,
+            "OnComponentUpdate": null,
+            "Ratio": 1,
+            "Scale": 128,
+            "UseParticleColor": true
+          }
+        ],
+        "Children": []
+      },
+      {
+        "__guid": "b01600a9-035e-4e0b-88d8-e384efeeb1fa",
+        "__version": 1,
+        "Flags": 0,
+        "Name": "Glow",
+        "Position": "2.447925,-0.0000003237589,0",
+        "Rotation": "0,0,0,1",
+        "Scale": "1,1,1",
+        "Tags": "particles",
+        "Enabled": true,
+        "NetworkMode": 2,
+        "NetworkInterpolation": true,
+        "NetworkOrphaned": 0,
+        "OwnerTransfer": 1,
+        "Components": [
+          {
+            "__type": "Sandbox.ParticleEffect",
+            "__guid": "c1cc416d-0fab-4b8c-bab7-46facd1822db",
+            "__enabled": true,
+            "__version": 3,
+            "Alpha": {
+              "Type": "Curve",
+              "Evaluation": "Life",
+              "CurveA": [
+                {
+                  "x": 0,
+                  "y": 1,
+                  "in": -0,
+                  "out": -0,
+                  "mode": "Mirrored"
+                },
+                {
+                  "x": 1,
+                  "y": 0,
+                  "in": -0,
+                  "out": -0,
+                  "mode": "Mirrored"
+                }
+              ],
+              "CurveB": [
+                {
+                  "x": 0.5,
+                  "y": 0.5,
+                  "in": 0,
+                  "out": 0,
+                  "mode": "Mirrored"
+                }
+              ]
+            },
+            "ApplyAlpha": true,
+            "ApplyColor": true,
+            "ApplyRotation": true,
+            "ApplyShape": true,
+            "Bounce": 0.3,
+            "Brightness": 100,
+            "Bumpiness": 0,
+            "Collision": false,
+            "CollisionIgnore": null,
+            "CollisionPrefab": null,
+            "CollisionPrefabAlign": false,
+            "CollisionPrefabChance": 1,
+            "CollisionPrefabRotation": 0,
+            "CollisionRadius": 1,
+            "ConstantMovement": {
+              "X": 0,
+              "Y": 0,
+              "Z": 0
+            },
+            "Damping": 0,
+            "DieOnCollisionChance": 0.3,
+            "FollowerPrefab": null,
+            "FollowerPrefabChance": 1,
+            "FollowerPrefabKill": true,
+            "Force": false,
+            "ForceDirection": "0,0,-500",
+            "ForceScale": 1,
+            "ForceSpace": "World",
+            "Friction": 0.2,
+            "Gradient": {
+              "Type": "Range",
+              "Evaluation": "Particle",
+              "GradientA": {
+                "blend": "Linear",
+                "color": [
+                  {
+                    "t": 0.5,
+                    "c": "1,1,1,1"
+                  }
+                ],
+                "alpha": []
+              },
+              "GradientB": {
+                "blend": "Linear",
+                "color": [
+                  {
+                    "t": 0.5,
+                    "c": "1,1,1,1"
+                  }
+                ],
+                "alpha": []
+              },
+              "ConstantA": "0.8132,0.94949,0.97674,1",
+              "ConstantB": "0.2,0.6,1,1"
+            },
+            "InitialVelocity": {
+              "X": 0,
+              "Y": 0,
+              "Z": 0
+            },
+            "Lifetime": {
+              "Type": "Range",
+              "Evaluation": "Seed",
+              "Constants": "0.1,0.1,0,0"
+            },
+            "LocalSpace": {
+              "Type": "Curve",
+              "Evaluation": "Life",
+              "CurveA": [
+                {
+                  "x": 0,
+                  "y": 1,
+                  "in": -0,
+                  "out": -0,
+                  "mode": "Mirrored"
+                },
+                {
+                  "x": 1,
+                  "y": 0,
+                  "in": 3.1415927,
+                  "out": -3.1415927,
+                  "mode": "Mirrored"
+                }
+              ],
+              "CurveB": [
+                {
+                  "x": 0.5,
+                  "y": 0.5,
+                  "in": 0,
+                  "out": 0,
+                  "mode": "Mirrored"
+                }
+              ]
+            },
+            "MaxParticles": 5,
+            "OnComponentDestroy": null,
+            "OnComponentDisabled": null,
+            "OnComponentEnabled": null,
+            "OnComponentFixedUpdate": null,
+            "OnComponentStart": null,
+            "OnComponentUpdate": null,
+            "OnParticleCreated": null,
+            "OnParticleDestroyed": null,
+            "OrbitalForce": {
+              "X": 0,
+              "Y": 0,
+              "Z": 0
+            },
+            "OrbitalPull": 0,
+            "PerParticleTimeScale": 1,
+            "Pitch": {
+              "Type": "Range",
+              "Evaluation": "Seed",
+              "Constants": "0,360,0,0"
+            },
+            "PreWarm": 0,
+            "PushStrength": 0,
+            "Roll": {
+              "Type": "Range",
+              "Evaluation": "Seed",
+              "Constants": "0,360,0,0"
+            },
+            "Scale": {
+              "Type": "Range",
+              "Evaluation": "Frame",
+              "Constants": "20,5,0,0"
+            },
+            "SequenceId": 0,
+            "SequenceSpeed": 1,
+            "SequenceTime": 1,
+            "SheetSequence": false,
+            "StartDelay": 0,
+            "StartVelocity": {
+              "Type": "Range",
+              "Evaluation": "Seed",
+              "Constants": "0,0,0,0"
+            },
+            "Stretch": 0,
+            "TimeScale": 1,
+            "Timing": "GameTime",
+            "Tint": "1,1,1,1",
+            "UsePrefabFeature": false,
+            "Yaw": {
+              "Type": "Range",
+              "Evaluation": "Seed",
+              "Constants": "0,360,0,0"
+            }
+          },
+          {
+            "__type": "Sandbox.ParticleSpriteRenderer",
+            "__guid": "41cc5701-db82-4f95-95c2-f237a79b9239",
+            "__enabled": true,
+            "Additive": true,
+            "Alignment": "LookAtCamera",
+            "BlurAmount": 1,
+            "BlurOpacity": 1,
+            "BlurSpacing": 1,
+            "DepthFeather": 50,
+            "FaceVelocity": false,
+            "FogStrength": 1,
+            "LeadingTrail": true,
+            "Lighting": false,
+            "MotionBlur": false,
+            "OnComponentDestroy": null,
+            "OnComponentDisabled": null,
+            "OnComponentEnabled": null,
+            "OnComponentFixedUpdate": null,
+            "OnComponentStart": null,
+            "OnComponentUpdate": null,
+            "Opaque": false,
+            "Pivot": "0.51,0.5",
+            "RenderOptions": {
+              "GameLayer": true,
+              "OverlayLayer": false,
+              "BloomLayer": true,
+              "AfterUILayer": false
+            },
+            "RotationOffset": 0,
+            "Scale": 1,
+            "Shadows": false,
+            "SortMode": "Unsorted",
+            "Texture": {
+              "$compiler": "texture",
+              "$source": "imagefile",
+              "data": {
+                "FilePath": "textures/shapes/spark2.png",
+                "MaxSize": 4096,
+                "ConvertHeightToNormals": false,
+                "NormalScale": 1,
+                "Rotate": 0,
+                "FlipVertical": false,
+                "FlipHorizontal": false,
+                "Cropping": {
+                  "Left": 0,
+                  "Top": 0,
+                  "Right": 0,
+                  "Bottom": 0
+                },
+                "Padding": {
+                  "Left": 0,
+                  "Top": 0,
+                  "Right": 0,
+                  "Bottom": 0
+                },
+                "InvertColor": false,
+                "Tint": "1,1,1,1",
+                "Blur": 0,
+                "Sharpen": 0,
+                "Brightness": 1,
+                "Contrast": 1,
+                "Saturation": 1,
+                "Hue": 0,
+                "Colorize": false,
+                "TargetColor": "0,1,0,1",
+                "CacheToDisk": true
+              },
+              "compiled": null
+            },
+            "TextureFilter": "Bilinear"
+          },
+          {
+            "__type": "Sandbox.ParticleSphereEmitter",
+            "__guid": "af9216c1-64c1-4f53-823d-d076c691add5",
+            "__enabled": true,
+            "Burst": 0,
+            "Delay": 0,
+            "DestroyOnEnd": false,
+            "Duration": 10,
+            "Loop": true,
+            "OnComponentDestroy": null,
+            "OnComponentDisabled": null,
+            "OnComponentEnabled": null,
+            "OnComponentFixedUpdate": null,
+            "OnComponentStart": null,
+            "OnComponentUpdate": null,
+            "OnEdge": false,
+            "Radius": 1,
+            "Rate": 10,
+            "RateOverDistance": 0,
+            "Velocity": 0
+          }
+        ],
+        "Children": []
+      }
+    ],
+    "__properties": {
+      "NetworkInterpolation": true,
+      "TimeScale": 1,
+      "WantsSystemScene": true,
+      "Metadata": {},
+      "NavMesh": {
+        "Enabled": false,
+        "IncludeStaticBodies": true,
+        "IncludeKeyframedBodies": true,
+        "EditorAutoUpdate": true,
+        "AgentHeight": 64,
+        "AgentRadius": 16,
+        "AgentStepSize": 18,
+        "AgentMaxSlope": 40,
+        "ExcludedBodies": "",
+        "IncludedBodies": ""
+      }
+    },
+    "__variables": []
+  },
+  "ResourceVersion": 2,
+  "ShowInMenu": false,
+  "MenuPath": null,
+  "MenuIcon": null,
+  "DontBreakAsTemplate": false,
+  "__references": [],
+  "__version": 2
+}

--- a/Assets/prefabs/weapons/physgun/effects/freeze.prefab
+++ b/Assets/prefabs/weapons/physgun/effects/freeze.prefab
@@ -1,0 +1,961 @@
+{
+  "RootObject": {
+    "__guid": "e5cf5f34-17b5-4e70-b8db-d7f54a8ad61d",
+    "__version": 1,
+    "Flags": 0,
+    "Name": "freeze",
+    "Position": "0,0,0",
+    "Rotation": "0,0,0,1",
+    "Scale": "1,1,1",
+    "Tags": "",
+    "Enabled": true,
+    "NetworkMode": 2,
+    "NetworkInterpolation": true,
+    "NetworkOrphaned": 0,
+    "NetworkTransmit": true,
+    "OwnerTransfer": 1,
+    "Components": [
+      {
+        "__type": "TemporaryEffect",
+        "__guid": "efd434b8-3b7f-4dbf-be75-086c2abd0203",
+        "__enabled": true,
+        "BecomeOrphan": false,
+        "DestroyAfterSeconds": 1,
+        "OnComponentDestroy": null,
+        "OnComponentDisabled": null,
+        "OnComponentEnabled": null,
+        "OnComponentFixedUpdate": null,
+        "OnComponentStart": null,
+        "OnComponentUpdate": null,
+        "WaitForChildEffects": true
+      },
+      {
+        "__type": "Sandbox.SoundPointComponent",
+        "__guid": "3d53156e-8349-4719-a1f9-797f3a3886ca",
+        "__enabled": true,
+        "Distance": 512,
+        "DistanceAttenuation": false,
+        "DistanceAttenuationOverride": false,
+        "Falloff": [
+          {
+            "x": 0,
+            "y": 1,
+            "in": 3.1415927,
+            "out": -3.1415927,
+            "mode": "Mirrored"
+          },
+          {
+            "x": 1,
+            "y": 0,
+            "in": 0,
+            "out": 0,
+            "mode": "Mirrored"
+          }
+        ],
+        "Force2d": false,
+        "MaxRepeatTime": 1,
+        "MinRepeatTime": 1,
+        "Occlusion": false,
+        "OcclusionOverride": false,
+        "OcclusionRadius": 32,
+        "OnComponentDestroy": null,
+        "OnComponentDisabled": null,
+        "OnComponentEnabled": null,
+        "OnComponentFixedUpdate": null,
+        "OnComponentStart": null,
+        "OnComponentUpdate": null,
+        "Pitch": 1,
+        "PlayOnStart": true,
+        "ReflectionOverride": false,
+        "Reflections": false,
+        "Repeat": false,
+        "SoundEvent": "weapons/physgun/sounds/physgun.freeze.sound",
+        "SoundOverride": false,
+        "StopOnNew": false,
+        "TargetMixer": {
+          "Name": "unknown",
+          "Id": "00000000-0000-0000-0000-000000000000"
+        },
+        "Volume": 1
+      }
+    ],
+    "Children": [
+      {
+        "__guid": "d9a12be7-ae8f-4eff-8d9f-f4fc57d3545b",
+        "__version": 1,
+        "Flags": 0,
+        "Name": "Burst",
+        "Position": "0,0,0.8528237",
+        "Rotation": "0,0,0,1",
+        "Scale": "1,1,1",
+        "Tags": "particles",
+        "Enabled": true,
+        "NetworkMode": 2,
+        "NetworkInterpolation": true,
+        "NetworkOrphaned": 0,
+        "NetworkTransmit": true,
+        "OwnerTransfer": 1,
+        "Components": [
+          {
+            "__type": "Sandbox.ParticleEffect",
+            "__guid": "e6218df3-684f-4a4a-a6fe-1114daf080db",
+            "__enabled": true,
+            "__version": 3,
+            "Alpha": {
+              "Type": "CurveRange",
+              "Evaluation": "Life",
+              "CurveA": [
+                {
+                  "x": 0,
+                  "y": 0,
+                  "in": -0.97142893,
+                  "out": 0.97142893,
+                  "mode": "Mirrored"
+                },
+                {
+                  "x": 0.11444142,
+                  "y": 1,
+                  "in": 0,
+                  "out": 0,
+                  "mode": "Mirrored"
+                },
+                {
+                  "x": 1,
+                  "y": 0,
+                  "in": 6.0909085,
+                  "out": -6.0909085,
+                  "mode": "Mirrored"
+                }
+              ],
+              "CurveB": [
+                {
+                  "x": 0,
+                  "y": 0,
+                  "in": -0.91891897,
+                  "out": 0.91891897,
+                  "mode": "Mirrored"
+                },
+                {
+                  "x": 0.073569484,
+                  "y": 1,
+                  "in": 0,
+                  "out": 0,
+                  "mode": "Mirrored"
+                },
+                {
+                  "x": 1,
+                  "y": 0,
+                  "in": 3.3199997,
+                  "out": -3.3199997,
+                  "mode": "Mirrored"
+                }
+              ]
+            },
+            "ApplyAlpha": true,
+            "ApplyColor": true,
+            "ApplyRotation": true,
+            "ApplyShape": true,
+            "Bounce": 1,
+            "Brightness": {
+              "Type": "CurveRange",
+              "Evaluation": "Life",
+              "CurveA": {
+                "rangey": "0,100",
+                "frames": [
+                  {
+                    "x": 0,
+                    "y": 0.27822578,
+                    "in": 0.16098209,
+                    "out": -0.16098209,
+                    "mode": "Mirrored"
+                  },
+                  {
+                    "x": 1,
+                    "y": 0,
+                    "in": 0.3356071,
+                    "out": -0.3356071,
+                    "mode": "Mirrored"
+                  }
+                ]
+              },
+              "CurveB": {
+                "rangey": "0,100",
+                "frames": [
+                  {
+                    "x": 0,
+                    "y": 0.9395161,
+                    "in": 0.100278184,
+                    "out": -0.100278184,
+                    "mode": "Mirrored"
+                  },
+                  {
+                    "x": 1,
+                    "y": 0.58870965,
+                    "in": 0.39361706,
+                    "out": -0.39361706,
+                    "mode": "Mirrored"
+                  }
+                ]
+              }
+            },
+            "Bumpiness": 0,
+            "Collision": false,
+            "CollisionIgnore": null,
+            "CollisionPrefab": null,
+            "CollisionPrefabAlign": false,
+            "CollisionPrefabChance": 1,
+            "CollisionPrefabRotation": 0,
+            "CollisionRadius": 1,
+            "ConstantMovement": {
+              "X": {
+                "Type": "Range",
+                "Evaluation": "Seed",
+                "Constants": "0,0,0,0"
+              },
+              "Y": 0,
+              "Z": {
+                "Type": "Range",
+                "Evaluation": "Seed",
+                "Constants": "5,10,0,0"
+              }
+            },
+            "Damping": 2,
+            "DieOnCollisionChance": 0,
+            "FollowerPrefab": null,
+            "FollowerPrefabChance": 1,
+            "FollowerPrefabKill": true,
+            "Force": false,
+            "ForceDirection": "0,0,-800",
+            "ForceScale": 1,
+            "ForceSpace": "World",
+            "Friction": 1,
+            "Gradient": {
+              "Type": "Range",
+              "Evaluation": "Particle",
+              "GradientA": {
+                "blend": "Linear",
+                "color": [
+                  {
+                    "t": 0.5,
+                    "c": "1,1,1,1"
+                  }
+                ],
+                "alpha": []
+              },
+              "GradientB": {
+                "blend": "Linear",
+                "color": [
+                  {
+                    "t": 0.5,
+                    "c": "1,1,1,1"
+                  }
+                ],
+                "alpha": []
+              },
+              "ConstantA": "0.72558,0.96798,1,1",
+              "ConstantB": "0.09661,0.8453,0.94419,1"
+            },
+            "InitialVelocity": {
+              "X": 0,
+              "Y": 0,
+              "Z": 0
+            },
+            "Lifetime": {
+              "Type": "Range",
+              "Evaluation": "Seed",
+              "Constants": "0.1,0.15,0,0"
+            },
+            "LocalSpace": 0,
+            "MaxParticles": 5000,
+            "OnComponentDestroy": null,
+            "OnComponentDisabled": null,
+            "OnComponentEnabled": null,
+            "OnComponentFixedUpdate": null,
+            "OnComponentStart": null,
+            "OnComponentUpdate": null,
+            "OnParticleCreated": null,
+            "OnParticleDestroyed": null,
+            "OrbitalForce": {
+              "X": 0,
+              "Y": 0,
+              "Z": 0
+            },
+            "OrbitalPull": 0,
+            "PerParticleTimeScale": 1,
+            "Pitch": {
+              "Type": "Range",
+              "Evaluation": "Seed",
+              "Constants": "0,360,0,0"
+            },
+            "PreWarm": 0,
+            "PushStrength": 0,
+            "Roll": {
+              "Type": "Range",
+              "Evaluation": "Seed",
+              "Constants": "0,360,0,0"
+            },
+            "Scale": {
+              "Type": "CurveRange",
+              "Evaluation": "Life",
+              "CurveA": {
+                "rangey": "0,80",
+                "frames": [
+                  {
+                    "x": 0,
+                    "y": 0.20967746,
+                    "in": -0.19718336,
+                    "out": 0.19718336,
+                    "mode": "Mirrored"
+                  },
+                  {
+                    "x": 1,
+                    "y": 0.2298388,
+                    "in": 0.1910111,
+                    "out": -0.1910111,
+                    "mode": "Mirrored"
+                  }
+                ]
+              },
+              "CurveB": {
+                "rangey": "0,61",
+                "frames": [
+                  {
+                    "x": 0,
+                    "y": 0.07661294,
+                    "in": -0.40625045,
+                    "out": 0.40625045,
+                    "mode": "Mirrored"
+                  },
+                  {
+                    "x": 1,
+                    "y": 0.032258082,
+                    "in": 0.061538555,
+                    "out": -0.061538555,
+                    "mode": "Mirrored"
+                  }
+                ]
+              }
+            },
+            "SequenceId": 0,
+            "SequenceSpeed": 1,
+            "SequenceTime": 1,
+            "SheetSequence": false,
+            "StartDelay": {
+              "Type": "Range",
+              "Evaluation": "Seed",
+              "Constants": "0,0.1,0,0"
+            },
+            "StartVelocity": {
+              "Type": "Range",
+              "Evaluation": "Seed",
+              "Constants": "10,50,0,0"
+            },
+            "Stretch": 0,
+            "TimeScale": 1,
+            "Timing": "GameTime",
+            "Tint": "0.7907,0.98605,1,1",
+            "UsePrefabFeature": false,
+            "Yaw": {
+              "Type": "Range",
+              "Evaluation": "Seed",
+              "Constants": "0,360,0,0"
+            }
+          },
+          {
+            "__type": "Sandbox.ParticleSpriteRenderer",
+            "__guid": "19d464f6-8041-4eb8-bc4e-7f28a1bcea6f",
+            "__enabled": true,
+            "__version": 2,
+            "Additive": true,
+            "Alignment": "LookAtCamera",
+            "BlurAmount": 0.5,
+            "BlurOpacity": 0.91,
+            "BlurSpacing": 0.73,
+            "DepthFeather": 1.946472,
+            "FaceVelocity": false,
+            "FogStrength": 1,
+            "LeadingTrail": true,
+            "Lighting": false,
+            "MotionBlur": false,
+            "OnComponentDestroy": null,
+            "OnComponentDisabled": null,
+            "OnComponentEnabled": null,
+            "OnComponentFixedUpdate": null,
+            "OnComponentStart": null,
+            "OnComponentUpdate": null,
+            "Opaque": false,
+            "PlaybackSpeed": 1,
+            "RenderOptions": {
+              "GameLayer": true,
+              "OverlayLayer": false,
+              "BloomLayer": true,
+              "AfterUILayer": false
+            },
+            "RotationOffset": 0,
+            "Scale": 1.0413625,
+            "Shadows": false,
+            "SortMode": "Unsorted",
+            "Sprite": {
+              "$compiler": "embed",
+              "$source": null,
+              "data": {
+                "Animations": [
+                  {
+                    "Name": "Default",
+                    "FrameRate": 15,
+                    "Origin": "0.5,0.5",
+                    "LoopMode": "Loop",
+                    "Frames": [
+                      {
+                        "Texture": {
+                          "$compiler": "texture",
+                          "$source": "imagefile",
+                          "data": {
+                            "FilePath": "textures/beams/lightning.png",
+                            "MaxSize": 4096,
+                            "ConvertHeightToNormals": false,
+                            "NormalScale": 1,
+                            "Rotate": 0,
+                            "FlipVertical": false,
+                            "FlipHorizontal": false,
+                            "Cropping": {
+                              "Left": 0,
+                              "Top": 0,
+                              "Right": 0,
+                              "Bottom": 0
+                            },
+                            "Padding": {
+                              "Left": 0,
+                              "Top": 0,
+                              "Right": 0,
+                              "Bottom": 0
+                            },
+                            "InvertColor": false,
+                            "Tint": "1,1,1,1",
+                            "Blur": 0,
+                            "Sharpen": 0,
+                            "Brightness": 1,
+                            "Contrast": 1,
+                            "Saturation": 1,
+                            "Hue": 0,
+                            "Colorize": false,
+                            "TargetColor": "0,1,0,1",
+                            "CacheToDisk": true
+                          },
+                          "compiled": null
+                        },
+                        "BroadcastMessages": []
+                      }
+                    ]
+                  }
+                ],
+                "__references": null
+              },
+              "compiled": null
+            },
+            "StartingAnimationName": "Default",
+            "TextureFilter": "Bilinear"
+          },
+          {
+            "__type": "Sandbox.ParticleModelEmitter",
+            "__guid": "75f19837-721d-4a73-8988-70a21972aa3e",
+            "__enabled": true,
+            "Burst": 30,
+            "Delay": 0,
+            "DestroyOnEnd": false,
+            "Duration": 1,
+            "Loop": false,
+            "OnComponentDestroy": null,
+            "OnComponentDisabled": null,
+            "OnComponentEnabled": null,
+            "OnComponentFixedUpdate": null,
+            "OnComponentStart": null,
+            "OnComponentUpdate": null,
+            "OnEdge": true,
+            "Rate": 0,
+            "RateOverDistance": 0,
+            "Target": {
+              "_type": "gameobject",
+              "go": "474cbd24-69b5-4544-b895-5d00f4267072"
+            }
+          },
+          {
+            "__type": "Sandbox.ParticleLightRenderer",
+            "__guid": "fe319829-5fe7-447f-9175-55c4377571bc",
+            "__enabled": true,
+            "Attenuation": 4,
+            "Brightness": 1,
+            "CastShadows": false,
+            "LightColor": {
+              "Type": "Constant",
+              "Evaluation": "Life",
+              "GradientA": {
+                "blend": "Linear",
+                "color": [
+                  {
+                    "t": 0.5,
+                    "c": "1,1,1,1"
+                  }
+                ],
+                "alpha": []
+              },
+              "GradientB": {
+                "blend": "Linear",
+                "color": [
+                  {
+                    "t": 0.5,
+                    "c": "1,1,1,1"
+                  }
+                ],
+                "alpha": []
+              },
+              "ConstantA": "1,1,1,1",
+              "ConstantB": "1,1,1,1"
+            },
+            "MaximumLights": 8,
+            "OnComponentDestroy": null,
+            "OnComponentDisabled": null,
+            "OnComponentEnabled": null,
+            "OnComponentFixedUpdate": null,
+            "OnComponentStart": null,
+            "OnComponentUpdate": null,
+            "Ratio": 1,
+            "Scale": 8,
+            "UseParticleColor": true
+          }
+        ],
+        "Children": []
+      },
+      {
+        "__guid": "20362926-3f6f-471c-b4f0-e9f5690b06df",
+        "__version": 1,
+        "Flags": 0,
+        "Name": "Bits",
+        "Position": "0,0,0.8528237",
+        "Rotation": "0,0,0,1",
+        "Scale": "1,1,1",
+        "Tags": "particles",
+        "Enabled": true,
+        "NetworkMode": 2,
+        "NetworkInterpolation": true,
+        "NetworkOrphaned": 0,
+        "NetworkTransmit": true,
+        "OwnerTransfer": 1,
+        "Components": [
+          {
+            "__type": "Sandbox.ParticleEffect",
+            "__guid": "fc0dbbc6-8b27-415b-8909-152d0c248376",
+            "__enabled": true,
+            "__version": 3,
+            "Alpha": {
+              "Type": "Curve",
+              "Evaluation": "Life",
+              "CurveA": [
+                {
+                  "x": 0,
+                  "y": 1,
+                  "in": 3.1415927,
+                  "out": -3.1415927,
+                  "mode": "Mirrored"
+                },
+                {
+                  "x": 1,
+                  "y": 0,
+                  "in": -0,
+                  "out": -0,
+                  "mode": "Mirrored"
+                }
+              ],
+              "CurveB": [
+                {
+                  "x": 0,
+                  "y": 0,
+                  "in": -0.91891897,
+                  "out": 0.91891897,
+                  "mode": "Mirrored"
+                },
+                {
+                  "x": 0.10626703,
+                  "y": 0.6935484,
+                  "in": 0,
+                  "out": 0,
+                  "mode": "Mirrored"
+                },
+                {
+                  "x": 0.115803815,
+                  "y": 1.0000556,
+                  "in": 0,
+                  "out": 0,
+                  "mode": "Mirrored"
+                }
+              ]
+            },
+            "ApplyAlpha": true,
+            "ApplyColor": true,
+            "ApplyRotation": true,
+            "ApplyShape": true,
+            "Bounce": 1,
+            "Brightness": {
+              "Type": "CurveRange",
+              "Evaluation": "Life",
+              "CurveA": {
+                "rangey": "0,100",
+                "frames": [
+                  {
+                    "x": 0,
+                    "y": 0.733871,
+                    "in": 0.16098209,
+                    "out": -0.16098209,
+                    "mode": "Mirrored"
+                  },
+                  {
+                    "x": 1,
+                    "y": 0,
+                    "in": 0.3356071,
+                    "out": -0.3356071,
+                    "mode": "Mirrored"
+                  }
+                ]
+              },
+              "CurveB": {
+                "rangey": "0,100",
+                "frames": [
+                  {
+                    "x": 0,
+                    "y": 0.9395161,
+                    "in": 0.100278184,
+                    "out": -0.100278184,
+                    "mode": "Mirrored"
+                  },
+                  {
+                    "x": 1,
+                    "y": 0,
+                    "in": 0.39361706,
+                    "out": -0.39361706,
+                    "mode": "Mirrored"
+                  }
+                ]
+              }
+            },
+            "Bumpiness": 0,
+            "Collision": false,
+            "CollisionIgnore": null,
+            "CollisionPrefab": null,
+            "CollisionPrefabAlign": false,
+            "CollisionPrefabChance": 1,
+            "CollisionPrefabRotation": 0,
+            "CollisionRadius": 1,
+            "ConstantMovement": {
+              "X": {
+                "Type": "Range",
+                "Evaluation": "Seed",
+                "Constants": "0,0,0,0"
+              },
+              "Y": 0,
+              "Z": {
+                "Type": "CurveRange",
+                "Evaluation": "Life",
+                "CurveA": {
+                  "rangey": "0,10",
+                  "frames": [
+                    {
+                      "x": 0,
+                      "y": 0.07661295,
+                      "in": 0,
+                      "out": 0,
+                      "mode": "Mirrored"
+                    },
+                    {
+                      "x": 0.97002727,
+                      "y": 0,
+                      "in": 0,
+                      "out": 0,
+                      "mode": "Mirrored"
+                    }
+                  ]
+                },
+                "CurveB": {
+                  "rangey": "0,10",
+                  "frames": [
+                    {
+                      "x": 0,
+                      "y": 0.39112908,
+                      "in": 0,
+                      "out": 0,
+                      "mode": "Mirrored"
+                    },
+                    {
+                      "x": 1,
+                      "y": 0,
+                      "in": 0,
+                      "out": 0,
+                      "mode": "Mirrored"
+                    }
+                  ]
+                }
+              }
+            },
+            "Damping": 0,
+            "DieOnCollisionChance": 0,
+            "FollowerPrefab": null,
+            "FollowerPrefabChance": 1,
+            "FollowerPrefabKill": true,
+            "Force": false,
+            "ForceDirection": "0,0,200",
+            "ForceScale": 1,
+            "ForceSpace": "World",
+            "Friction": 1,
+            "Gradient": {
+              "Type": "Range",
+              "Evaluation": "Particle",
+              "GradientA": {
+                "blend": "Linear",
+                "color": [
+                  {
+                    "t": 0.5,
+                    "c": "1,1,1,1"
+                  }
+                ],
+                "alpha": []
+              },
+              "GradientB": {
+                "blend": "Linear",
+                "color": [
+                  {
+                    "t": 0.5,
+                    "c": "1,1,1,1"
+                  }
+                ],
+                "alpha": []
+              },
+              "ConstantA": "0.72558,0.96798,1,1",
+              "ConstantB": "0.09661,0.8453,0.94419,1"
+            },
+            "InitialVelocity": {
+              "X": 0,
+              "Y": 0,
+              "Z": 0
+            },
+            "Lifetime": {
+              "Type": "Range",
+              "Evaluation": "Seed",
+              "Constants": "1,2,0,0"
+            },
+            "LocalSpace": 0,
+            "MaxParticles": 5000,
+            "OnComponentDestroy": null,
+            "OnComponentDisabled": null,
+            "OnComponentEnabled": null,
+            "OnComponentFixedUpdate": null,
+            "OnComponentStart": null,
+            "OnComponentUpdate": null,
+            "OnParticleCreated": null,
+            "OnParticleDestroyed": null,
+            "OrbitalForce": {
+              "X": 0,
+              "Y": 0,
+              "Z": 0
+            },
+            "OrbitalPull": 0,
+            "PerParticleTimeScale": 1,
+            "Pitch": {
+              "Type": "Range",
+              "Evaluation": "Seed",
+              "Constants": "0,360,0,0"
+            },
+            "PreWarm": 0,
+            "PushStrength": 0,
+            "Roll": {
+              "Type": "Range",
+              "Evaluation": "Seed",
+              "Constants": "0,360,0,0"
+            },
+            "Scale": {
+              "Type": "Range",
+              "Evaluation": "Seed",
+              "Constants": "0.1,0.2,0,0"
+            },
+            "SequenceId": 0,
+            "SequenceSpeed": 1,
+            "SequenceTime": 1,
+            "SheetSequence": false,
+            "StartDelay": {
+              "Type": "Range",
+              "Evaluation": "Seed",
+              "Constants": "0,0.1,0,0"
+            },
+            "StartVelocity": {
+              "Type": "Range",
+              "Evaluation": "Seed",
+              "Constants": "0,0,0,0"
+            },
+            "Stretch": 0,
+            "TimeScale": 1,
+            "Timing": "GameTime",
+            "Tint": "0.7907,0.98605,1,1",
+            "UsePrefabFeature": false,
+            "Yaw": {
+              "Type": "Range",
+              "Evaluation": "Seed",
+              "Constants": "0,360,0,0"
+            }
+          },
+          {
+            "__type": "Sandbox.ParticleSpriteRenderer",
+            "__guid": "9690bb90-e03d-4439-8ed6-b5849fd0c0f4",
+            "__enabled": true,
+            "__version": 2,
+            "Additive": true,
+            "Alignment": "LookAtCamera",
+            "BlurAmount": 1,
+            "BlurOpacity": 1,
+            "BlurSpacing": 1,
+            "DepthFeather": 0,
+            "FaceVelocity": false,
+            "FogStrength": 1,
+            "LeadingTrail": true,
+            "Lighting": false,
+            "MotionBlur": false,
+            "OnComponentDestroy": null,
+            "OnComponentDisabled": null,
+            "OnComponentEnabled": null,
+            "OnComponentFixedUpdate": null,
+            "OnComponentStart": null,
+            "OnComponentUpdate": null,
+            "Opaque": false,
+            "PlaybackSpeed": 1,
+            "RenderOptions": {
+              "GameLayer": true,
+              "OverlayLayer": false,
+              "BloomLayer": false,
+              "AfterUILayer": false
+            },
+            "RotationOffset": 0,
+            "Scale": 1.0413625,
+            "Shadows": false,
+            "SortMode": "Unsorted",
+            "Sprite": {
+              "$compiler": "embed",
+              "$source": null,
+              "data": {
+                "Animations": [
+                  {
+                    "Name": "Default",
+                    "FrameRate": 15,
+                    "Origin": "0.5,0.5",
+                    "LoopMode": "Loop",
+                    "Frames": [
+                      {
+                        "Texture": "textures/particles/base_sprite.vtex",
+                        "BroadcastMessages": []
+                      }
+                    ]
+                  }
+                ],
+                "__references": null
+              },
+              "compiled": null
+            },
+            "StartingAnimationName": "Default",
+            "TextureFilter": "Bilinear"
+          },
+          {
+            "__type": "Sandbox.ParticleModelEmitter",
+            "__guid": "1d35bc18-4552-4e13-871f-1909db4523b8",
+            "__enabled": true,
+            "Burst": 30,
+            "Delay": 0,
+            "DestroyOnEnd": false,
+            "Duration": 1,
+            "Loop": false,
+            "OnComponentDestroy": null,
+            "OnComponentDisabled": null,
+            "OnComponentEnabled": null,
+            "OnComponentFixedUpdate": null,
+            "OnComponentStart": null,
+            "OnComponentUpdate": null,
+            "OnEdge": true,
+            "Rate": 0,
+            "RateOverDistance": 0,
+            "Target": {
+              "_type": "gameobject",
+              "go": "474cbd24-69b5-4544-b895-5d00f4267072"
+            }
+          }
+        ],
+        "Children": []
+      },
+      {
+        "__guid": "474cbd24-69b5-4544-b895-5d00f4267072",
+        "__version": 1,
+        "Flags": 2048,
+        "Name": "Cube",
+        "Position": "0,0,63.26761",
+        "Rotation": "0,0,0,1",
+        "Scale": "1,1,1",
+        "Tags": "",
+        "Enabled": true,
+        "NetworkMode": 2,
+        "NetworkInterpolation": true,
+        "NetworkOrphaned": 0,
+        "NetworkTransmit": true,
+        "OwnerTransfer": 1,
+        "Components": [
+          {
+            "__type": "Sandbox.ModelRenderer",
+            "__guid": "2312c690-e7fc-4a98-bf63-3082c6fa519c",
+            "__enabled": true,
+            "BodyGroups": 18446744073709551615,
+            "CreateAttachments": false,
+            "LodOverride": null,
+            "MaterialGroup": null,
+            "MaterialOverride": null,
+            "Materials": null,
+            "Model": "models/dev/error.vmdl",
+            "OnComponentDestroy": null,
+            "OnComponentDisabled": null,
+            "OnComponentEnabled": null,
+            "OnComponentFixedUpdate": null,
+            "OnComponentStart": null,
+            "OnComponentUpdate": null,
+            "RenderOptions": {
+              "GameLayer": true,
+              "OverlayLayer": false,
+              "BloomLayer": false,
+              "AfterUILayer": false
+            },
+            "RenderType": "On",
+            "Tint": "0.24186,0.24186,0.24186,1"
+          }
+        ],
+        "Children": []
+      }
+    ],
+    "__properties": {
+      "NetworkInterpolation": true,
+      "TimeScale": 1,
+      "WantsSystemScene": true,
+      "Metadata": {},
+      "NavMesh": {
+        "Enabled": false,
+        "IncludeStaticBodies": true,
+        "IncludeKeyframedBodies": true,
+        "EditorAutoUpdate": true,
+        "AgentHeight": 64,
+        "AgentRadius": 16,
+        "AgentStepSize": 18,
+        "AgentMaxSlope": 40,
+        "ExcludedBodies": "",
+        "IncludedBodies": ""
+      }
+    },
+    "__variables": []
+  },
+  "ResourceVersion": 2,
+  "ShowInMenu": false,
+  "MenuPath": null,
+  "MenuIcon": null,
+  "DontBreakAsTemplate": false,
+  "__references": [],
+  "__version": 2
+}

--- a/Assets/prefabs/weapons/physgun/effects/grab-ball.vmat
+++ b/Assets/prefabs/weapons/physgun/effects/grab-ball.vmat
@@ -1,0 +1,56 @@
+// THIS FILE IS AUTO-GENERATED
+
+Layer0
+{
+	shader "shaders/complex.shader"
+
+	//---- PBR ----
+	F_SELF_ILLUM 1
+
+	//---- Translucent ----
+	F_ADDITIVE_BLEND 1
+	F_TRANSLUCENT 1
+
+	//---- Ambient Occlusion ----
+	g_flAmbientOcclusionDirectDiffuse "0.000"
+	TextureAmbientOcclusion "materials/default/default_ao.tga"
+
+	//---- Color ----
+	g_flModelTintAmount "1.000"
+	g_vColorTint "[1.000000 1.000000 1.000000 0.000000]"
+	TextureColor "materials/default/default_color.tga"
+
+	//---- Fade ----
+	g_flFadeExponent "1.000"
+
+	//---- Fog ----
+	g_bFogEnabled "1"
+
+	//---- Metalness ----
+	g_flMetalness "0.000"
+
+	//---- Normal ----
+	TextureNormal "materials/default/default_normal.tga"
+
+	//---- Roughness ----
+	g_flRoughnessScaleFactor "1.000"
+	TextureRoughness "materials/default/default_rough.tga"
+
+	//---- Self Illum ----
+	g_flSelfIllumAlbedoFactor "1.000"
+	g_flSelfIllumBrightness "7.594"
+	g_flSelfIllumScale "1.000"
+	g_vSelfIllumOffset "[0.000 0.000]"
+	g_vSelfIllumScrollSpeed "[0.000 0.000]"
+	g_vSelfIllumTint "[0.384314 0.721569 1.000000 0.000000]"
+	TextureSelfIllumMask "[1.000000 1.000000 1.000000 0.000000]"
+
+	//---- Texture Coordinates ----
+	g_vTexCoordOffset "[0.000 0.000]"
+	g_vTexCoordScale "[1.000 1.000]"
+	g_vTexCoordScrollSpeed "[4.463 -1.944]"
+
+	//---- Translucent ----
+	g_flOpacityScale "1.000"
+	TextureTranslucency "textures/shapes/ring1.png"
+}

--- a/Assets/prefabs/weapons/physgun/effects/grab-spark.prefab
+++ b/Assets/prefabs/weapons/physgun/effects/grab-spark.prefab
@@ -1,0 +1,556 @@
+{
+  "RootObject": {
+    "__guid": "e5cf5f34-17b5-4e70-b8db-d7f54a8ad61d",
+    "__version": 1,
+    "Flags": 0,
+    "Name": "grab-spark",
+    "Position": "0,0,0",
+    "Rotation": "0,0,0,1",
+    "Scale": "1,1,1",
+    "Tags": "",
+    "Enabled": true,
+    "NetworkMode": 2,
+    "NetworkInterpolation": true,
+    "NetworkOrphaned": 0,
+    "NetworkTransmit": true,
+    "OwnerTransfer": 1,
+    "Components": [
+      {
+        "__type": "TemporaryEffect",
+        "__guid": "efd434b8-3b7f-4dbf-be75-086c2abd0203",
+        "__enabled": true,
+        "BecomeOrphan": false,
+        "DestroyAfterSeconds": 1,
+        "OnComponentDestroy": null,
+        "OnComponentDisabled": null,
+        "OnComponentEnabled": null,
+        "OnComponentFixedUpdate": null,
+        "OnComponentStart": null,
+        "OnComponentUpdate": null,
+        "WaitForChildEffects": true
+      },
+      {
+        "__type": "Sandbox.SoundPointComponent",
+        "__guid": "c64eb98a-87e9-49d9-b51e-7988c59be6a4",
+        "__enabled": true,
+        "Distance": 512,
+        "DistanceAttenuation": false,
+        "DistanceAttenuationOverride": false,
+        "Falloff": [
+          {
+            "x": 0,
+            "y": 1,
+            "in": 3.1415927,
+            "out": -3.1415927,
+            "mode": "Mirrored"
+          },
+          {
+            "x": 1,
+            "y": 0,
+            "in": 0,
+            "out": 0,
+            "mode": "Mirrored"
+          }
+        ],
+        "Force2d": false,
+        "MaxRepeatTime": 1,
+        "MinRepeatTime": 1,
+        "Occlusion": false,
+        "OcclusionOverride": false,
+        "OcclusionRadius": 32,
+        "OnComponentDestroy": null,
+        "OnComponentDisabled": null,
+        "OnComponentEnabled": null,
+        "OnComponentFixedUpdate": null,
+        "OnComponentStart": null,
+        "OnComponentUpdate": null,
+        "Pitch": 1,
+        "PlayOnStart": true,
+        "ReflectionOverride": false,
+        "Reflections": false,
+        "Repeat": false,
+        "SoundEvent": "weapons/physgun/sounds/physgun.attach.sound",
+        "SoundOverride": false,
+        "StopOnNew": false,
+        "TargetMixer": {
+          "Name": "unknown",
+          "Id": "00000000-0000-0000-0000-000000000000"
+        },
+        "Volume": 1
+      }
+    ],
+    "Children": [
+      {
+        "__guid": "3c984bfe-badb-4ad4-99b2-9bef33efff49",
+        "__version": 1,
+        "Flags": 0,
+        "Name": "Spray (1)",
+        "Position": "3.417858,-0.0000003237589,0",
+        "Rotation": "0,0,0,1",
+        "Scale": "1,1,1",
+        "Tags": "particles",
+        "Enabled": true,
+        "NetworkMode": 2,
+        "NetworkInterpolation": true,
+        "NetworkOrphaned": 0,
+        "NetworkTransmit": true,
+        "OwnerTransfer": 1,
+        "Components": [
+          {
+            "__type": "Sandbox.ParticleEffect",
+            "__guid": "6fa4873a-8089-475d-8e09-ba8179e715f8",
+            "__enabled": true,
+            "__version": 3,
+            "Alpha": {
+              "Type": "Curve",
+              "Evaluation": "Life",
+              "CurveA": [
+                {
+                  "x": 0,
+                  "y": 1,
+                  "in": 0,
+                  "out": 0,
+                  "mode": "Mirrored"
+                },
+                {
+                  "x": 0.48029557,
+                  "y": 1,
+                  "in": 1.5365853,
+                  "out": -1.5365853,
+                  "mode": "Mirrored"
+                },
+                {
+                  "x": 1,
+                  "y": 0,
+                  "in": 1.312303,
+                  "out": -1.312303,
+                  "mode": "Mirrored"
+                }
+              ],
+              "CurveB": [
+                {
+                  "x": 0.5,
+                  "y": 0.5,
+                  "in": 0,
+                  "out": 0,
+                  "mode": "Mirrored"
+                }
+              ]
+            },
+            "ApplyAlpha": true,
+            "ApplyColor": true,
+            "ApplyRotation": false,
+            "ApplyShape": true,
+            "Bounce": 0.3,
+            "Brightness": {
+              "Type": "Curve",
+              "Evaluation": "Life",
+              "CurveA": {
+                "rangey": "0,100",
+                "frames": [
+                  {
+                    "x": 0,
+                    "y": 1,
+                    "in": 2.625,
+                    "out": -2.625,
+                    "mode": "Mirrored"
+                  },
+                  {
+                    "x": 1,
+                    "y": 0,
+                    "in": 0.022727339,
+                    "out": -0.022727339,
+                    "mode": "Mirrored"
+                  }
+                ]
+              },
+              "CurveB": [
+                {
+                  "x": 0.5,
+                  "y": 0.5,
+                  "in": 0,
+                  "out": 0,
+                  "mode": "Mirrored"
+                }
+              ]
+            },
+            "Bumpiness": 0,
+            "Collision": false,
+            "CollisionIgnore": null,
+            "CollisionPrefab": null,
+            "CollisionPrefabAlign": false,
+            "CollisionPrefabChance": 1,
+            "CollisionPrefabRotation": 0,
+            "CollisionRadius": 1,
+            "ConstantMovement": {
+              "X": 0,
+              "Y": 0,
+              "Z": 0
+            },
+            "Damping": 5,
+            "DieOnCollisionChance": 0.3,
+            "FollowerPrefab": null,
+            "FollowerPrefabChance": 1,
+            "FollowerPrefabKill": true,
+            "Force": true,
+            "ForceDirection": "0,0,-200",
+            "ForceScale": 1,
+            "ForceSpace": "World",
+            "Friction": 0.2,
+            "Gradient": {
+              "Type": "Range",
+              "Evaluation": "Particle",
+              "GradientA": {
+                "blend": "Linear",
+                "color": [
+                  {
+                    "t": 0.5,
+                    "c": "1,1,1,1"
+                  }
+                ],
+                "alpha": []
+              },
+              "GradientB": {
+                "blend": "Linear",
+                "color": [
+                  {
+                    "t": 0.5,
+                    "c": "1,1,1,1"
+                  }
+                ],
+                "alpha": []
+              },
+              "ConstantA": "0.8132,0.94949,0.97674,1",
+              "ConstantB": "0.2,0.6,1,1"
+            },
+            "InitialVelocity": {
+              "X": 0,
+              "Y": 0,
+              "Z": 0
+            },
+            "Lifetime": {
+              "Type": "Range",
+              "Evaluation": "Seed",
+              "Constants": "0.2,0.4,0,0"
+            },
+            "LocalSpace": {
+              "Type": "Curve",
+              "Evaluation": "Life",
+              "CurveA": {
+                "rangex": "0,0.4234375",
+                "frames": [
+                  {
+                    "x": 0,
+                    "y": 1,
+                    "in": 2.4038465,
+                    "out": -2.4038465,
+                    "mode": "Mirrored"
+                  },
+                  {
+                    "x": 1,
+                    "y": 0,
+                    "in": 0,
+                    "out": 0,
+                    "mode": "Mirrored"
+                  }
+                ]
+              },
+              "CurveB": [
+                {
+                  "x": 0.5,
+                  "y": 0.5,
+                  "in": 0,
+                  "out": 0,
+                  "mode": "Mirrored"
+                }
+              ]
+            },
+            "MaxParticles": 5000,
+            "OnComponentDestroy": null,
+            "OnComponentDisabled": null,
+            "OnComponentEnabled": null,
+            "OnComponentFixedUpdate": null,
+            "OnComponentStart": null,
+            "OnComponentUpdate": null,
+            "OnParticleCreated": null,
+            "OnParticleDestroyed": null,
+            "OrbitalForce": {
+              "X": 0,
+              "Y": 0,
+              "Z": 0
+            },
+            "OrbitalPull": 0,
+            "PerParticleTimeScale": 1,
+            "Pitch": 0,
+            "PreWarm": 0,
+            "PushStrength": 0,
+            "Roll": 0,
+            "Scale": {
+              "Type": "CurveRange",
+              "Evaluation": "Life",
+              "CurveA": {
+                "rangey": "0,6",
+                "frames": [
+                  {
+                    "x": 0,
+                    "y": 0.185484,
+                    "in": 7.7882873E-07,
+                    "out": -7.7882873E-07,
+                    "mode": "Mirrored"
+                  },
+                  {
+                    "x": 0.1880109,
+                    "y": 0.07718992,
+                    "in": 0,
+                    "out": 0,
+                    "mode": "Mirrored"
+                  },
+                  {
+                    "x": 1,
+                    "y": 0,
+                    "in": 0,
+                    "out": 0,
+                    "mode": "Mirrored"
+                  }
+                ]
+              },
+              "CurveB": {
+                "rangey": "0,4",
+                "frames": [
+                  {
+                    "x": 0,
+                    "y": 0.05645162,
+                    "in": 0.35714334,
+                    "out": -0.35714334,
+                    "mode": "Mirrored"
+                  },
+                  {
+                    "x": 0.1893733,
+                    "y": 0.03729546,
+                    "in": 0,
+                    "out": 0,
+                    "mode": "Mirrored"
+                  },
+                  {
+                    "x": 1,
+                    "y": 0,
+                    "in": 0,
+                    "out": 0,
+                    "mode": "Mirrored"
+                  }
+                ]
+              }
+            },
+            "SequenceId": 0,
+            "SequenceSpeed": 1,
+            "SequenceTime": 1,
+            "SheetSequence": false,
+            "StartDelay": 0,
+            "StartVelocity": {
+              "Type": "Range",
+              "Evaluation": "Seed",
+              "Constants": "100,200,0,0"
+            },
+            "Stretch": 0,
+            "TimeScale": 1,
+            "Timing": "GameTime",
+            "Tint": "1,1,1,1",
+            "UsePrefabFeature": false,
+            "Yaw": {
+              "Type": "Range",
+              "Evaluation": "Seed",
+              "Constants": "0,360,0,0"
+            }
+          },
+          {
+            "__type": "Sandbox.ParticleSpriteRenderer",
+            "__guid": "75f967d5-8894-4b66-ae28-0205140d9b79",
+            "__enabled": true,
+            "__version": 2,
+            "Additive": true,
+            "Alignment": "LookAtCamera",
+            "BlurAmount": 1,
+            "BlurOpacity": 1,
+            "BlurSpacing": 1,
+            "DepthFeather": 0,
+            "FaceVelocity": false,
+            "FogStrength": 1,
+            "LeadingTrail": true,
+            "Lighting": false,
+            "MotionBlur": true,
+            "OnComponentDestroy": null,
+            "OnComponentDisabled": null,
+            "OnComponentEnabled": null,
+            "OnComponentFixedUpdate": null,
+            "OnComponentStart": null,
+            "OnComponentUpdate": null,
+            "Opaque": false,
+            "PlaybackSpeed": 1,
+            "RenderOptions": {
+              "GameLayer": true,
+              "OverlayLayer": false,
+              "BloomLayer": true,
+              "AfterUILayer": false
+            },
+            "RotationOffset": 0,
+            "Scale": 1,
+            "Shadows": false,
+            "SortMode": "Unsorted",
+            "Sprite": {
+              "$compiler": "embed",
+              "$source": null,
+              "data": {
+                "Animations": [
+                  {
+                    "Name": "Default",
+                    "FrameRate": 15,
+                    "Origin": "0.5,0.5",
+                    "LoopMode": "Loop",
+                    "Frames": [
+                      {
+                        "Texture": {
+                          "$compiler": "texture",
+                          "$source": "imagefile",
+                          "data": {
+                            "FilePath": "textures/shapes/triangle1.png",
+                            "MaxSize": 4096,
+                            "ConvertHeightToNormals": false,
+                            "NormalScale": 1,
+                            "Rotate": 0,
+                            "FlipVertical": false,
+                            "FlipHorizontal": false,
+                            "Cropping": {
+                              "Left": 0,
+                              "Top": 0,
+                              "Right": 0,
+                              "Bottom": 0
+                            },
+                            "Padding": {
+                              "Left": 0,
+                              "Top": 0,
+                              "Right": 0,
+                              "Bottom": 0
+                            },
+                            "InvertColor": false,
+                            "Tint": "1,1,1,1",
+                            "Blur": 0,
+                            "Sharpen": 0,
+                            "Brightness": 1,
+                            "Contrast": 1,
+                            "Saturation": 1,
+                            "Hue": 0,
+                            "Colorize": false,
+                            "TargetColor": "0,1,0,1",
+                            "CacheToDisk": true
+                          },
+                          "compiled": "textures/generated/imagefile/760a6cd994d08dc9.vtex"
+                        },
+                        "BroadcastMessages": []
+                      }
+                    ]
+                  }
+                ],
+                "__references": null
+              },
+              "compiled": null
+            },
+            "StartingAnimationName": "Default",
+            "TextureFilter": "Bilinear"
+          },
+          {
+            "__type": "Sandbox.ParticleLightRenderer",
+            "__guid": "bf89b65f-67a0-41b3-97c8-c524fae0f9a5",
+            "__enabled": true,
+            "Attenuation": 1,
+            "Brightness": 0.2,
+            "CastShadows": false,
+            "LightColor": {
+              "Type": "Constant",
+              "Evaluation": "Life",
+              "GradientA": {
+                "blend": "Linear",
+                "color": [
+                  {
+                    "t": 0.5,
+                    "c": "1,1,1,1"
+                  }
+                ],
+                "alpha": []
+              },
+              "GradientB": {
+                "blend": "Linear",
+                "color": [
+                  {
+                    "t": 0.5,
+                    "c": "1,1,1,1"
+                  }
+                ],
+                "alpha": []
+              },
+              "ConstantA": "1,1,1,1",
+              "ConstantB": "1,1,1,1"
+            },
+            "MaximumLights": 8,
+            "OnComponentDestroy": null,
+            "OnComponentDisabled": null,
+            "OnComponentEnabled": null,
+            "OnComponentFixedUpdate": null,
+            "OnComponentStart": null,
+            "OnComponentUpdate": null,
+            "Ratio": 1,
+            "Scale": 128,
+            "UseParticleColor": true
+          },
+          {
+            "__type": "Sandbox.ParticleSphereEmitter",
+            "__guid": "231b77ee-df33-44b0-997f-91ca013cb081",
+            "__enabled": true,
+            "Burst": 20,
+            "Delay": 0,
+            "DestroyOnEnd": false,
+            "Duration": 1,
+            "Loop": false,
+            "OnComponentDestroy": null,
+            "OnComponentDisabled": null,
+            "OnComponentEnabled": null,
+            "OnComponentFixedUpdate": null,
+            "OnComponentStart": null,
+            "OnComponentUpdate": null,
+            "OnEdge": false,
+            "Radius": 1,
+            "Rate": 0,
+            "RateOverDistance": 0,
+            "Velocity": 100
+          }
+        ],
+        "Children": []
+      }
+    ],
+    "__properties": {
+      "NetworkInterpolation": true,
+      "TimeScale": 1,
+      "WantsSystemScene": true,
+      "Metadata": {},
+      "NavMesh": {
+        "Enabled": false,
+        "IncludeStaticBodies": true,
+        "IncludeKeyframedBodies": true,
+        "EditorAutoUpdate": true,
+        "AgentHeight": 64,
+        "AgentRadius": 16,
+        "AgentStepSize": 18,
+        "AgentMaxSlope": 40,
+        "ExcludedBodies": "",
+        "IncludedBodies": ""
+      }
+    },
+    "__variables": []
+  },
+  "ResourceVersion": 2,
+  "ShowInMenu": false,
+  "MenuPath": null,
+  "MenuIcon": null,
+  "DontBreakAsTemplate": false,
+  "__references": [],
+  "__version": 2
+}

--- a/Assets/prefabs/weapons/physgun/effects/grab.prefab
+++ b/Assets/prefabs/weapons/physgun/effects/grab.prefab
@@ -1,0 +1,618 @@
+{
+  "RootObject": {
+    "__guid": "e5cf5f34-17b5-4e70-b8db-d7f54a8ad61d",
+    "__version": 2,
+    "Flags": 0,
+    "Name": "grab",
+    "Position": "0,0,0",
+    "Rotation": "0,0,0,1",
+    "Scale": "1,1,1",
+    "Tags": "",
+    "Enabled": true,
+    "NetworkMode": 2,
+    "NetworkFlags": 0,
+    "NetworkOrphaned": 0,
+    "NetworkTransmit": true,
+    "OwnerTransfer": 1,
+    "Components": [],
+    "Children": [
+      {
+        "__guid": "102a1867-a47d-4746-896d-1152d2f17c2b",
+        "__version": 2,
+        "Flags": 0,
+        "Name": "Sphere",
+        "Position": "0.400000006,0,0",
+        "Rotation": "0,0,0,1",
+        "Scale": "0.0500000007,0.0500000007,0.0500000007",
+        "Tags": "",
+        "Enabled": true,
+        "NetworkMode": 2,
+        "NetworkFlags": 0,
+        "NetworkOrphaned": 0,
+        "NetworkTransmit": true,
+        "OwnerTransfer": 1,
+        "Components": [
+          {
+            "__type": "Sandbox.ModelRenderer",
+            "__guid": "8941104c-19b0-4a94-99dc-71c9bf66f99d",
+            "__enabled": true,
+            "Flags": 0,
+            "BodyGroups": 18446744073709551615,
+            "CreateAttachments": false,
+            "LodOverride": null,
+            "MaterialGroup": null,
+            "MaterialOverride": "prefabs/weapons/physgun/effects/grab-ball.vmat",
+            "Materials": null,
+            "Model": "models/dev/sphere.vmdl",
+            "OnComponentDestroy": null,
+            "OnComponentDisabled": null,
+            "OnComponentEnabled": null,
+            "OnComponentFixedUpdate": null,
+            "OnComponentStart": null,
+            "OnComponentUpdate": null,
+            "RenderOptions": {
+              "GameLayer": true,
+              "OverlayLayer": false,
+              "BloomLayer": false,
+              "AfterUILayer": false
+            },
+            "RenderType": "On",
+            "Tint": "1,1,1,1"
+          }
+        ],
+        "Children": []
+      },
+      {
+        "__guid": "1eae2057-8084-44a1-ab7d-4d0b9d042bc9",
+        "__version": 2,
+        "Flags": 0,
+        "Name": "Sphere (1)",
+        "Position": "0.5,0,0",
+        "Rotation": "-0.5,0.5,0.5,0.5",
+        "Scale": "0.0599999987,0.0599999987,0.0599999987",
+        "Tags": "",
+        "Enabled": true,
+        "NetworkMode": 2,
+        "NetworkFlags": 0,
+        "NetworkOrphaned": 0,
+        "NetworkTransmit": true,
+        "OwnerTransfer": 1,
+        "Components": [
+          {
+            "__type": "Sandbox.ModelRenderer",
+            "__guid": "bc31acd8-dc5b-4d97-bb20-abccbc41cbc8",
+            "__enabled": true,
+            "Flags": 0,
+            "BodyGroups": 18446744073709551615,
+            "CreateAttachments": false,
+            "LodOverride": null,
+            "MaterialGroup": null,
+            "MaterialOverride": "prefabs/weapons/physgun/effects/grab-ball.vmat",
+            "Materials": null,
+            "Model": "models/dev/sphere.vmdl",
+            "OnComponentDestroy": null,
+            "OnComponentDisabled": null,
+            "OnComponentEnabled": null,
+            "OnComponentFixedUpdate": null,
+            "OnComponentStart": null,
+            "OnComponentUpdate": null,
+            "RenderOptions": {
+              "GameLayer": true,
+              "OverlayLayer": false,
+              "BloomLayer": false,
+              "AfterUILayer": false
+            },
+            "RenderType": "On",
+            "Tint": "0.19903,0.62556,0.93023,1"
+          }
+        ],
+        "Children": []
+      },
+      {
+        "__guid": "e137bc70-3420-4d70-be8d-bb36514db654",
+        "__version": 2,
+        "Flags": 0,
+        "Name": "effect",
+        "Position": "0,0,0",
+        "Rotation": "0,0,0,1",
+        "Scale": "1,1,1",
+        "Tags": "",
+        "Enabled": true,
+        "NetworkMode": 2,
+        "NetworkFlags": 0,
+        "NetworkOrphaned": 0,
+        "NetworkTransmit": true,
+        "OwnerTransfer": 1,
+        "Components": [
+          {
+            "__type": "PrefabSpawner",
+            "__guid": "c938ef27-c4f3-406f-9211-8d6a36bf8287",
+            "__enabled": true,
+            "Flags": 0,
+            "AsChild": false,
+            "OnComponentDestroy": null,
+            "OnComponentDisabled": null,
+            "OnComponentEnabled": null,
+            "OnComponentFixedUpdate": null,
+            "OnComponentStart": null,
+            "OnComponentUpdate": null,
+            "Prefab": {
+              "_type": "gameobject",
+              "prefab": "weapons/physgun/effects/grab-spark.prefab"
+            },
+            "SpawnOnDisabled": false,
+            "SpawnOnEnabled": true
+          }
+        ],
+        "Children": []
+      },
+      {
+        "__guid": "3c06d747-a92f-49b3-9749-0902446440a0",
+        "__version": 2,
+        "Flags": 0,
+        "Name": "Point Light",
+        "Position": "2.45907593,0,0",
+        "Rotation": "0,0,0,1",
+        "Scale": "1,1,1",
+        "Tags": "light_point,light",
+        "Enabled": true,
+        "NetworkMode": 2,
+        "NetworkFlags": 0,
+        "NetworkOrphaned": 0,
+        "NetworkTransmit": true,
+        "OwnerTransfer": 1,
+        "Components": [
+          {
+            "__type": "Sandbox.PointLight",
+            "__guid": "1eade6ef-bca3-4844-967d-98d7e79c224e",
+            "__enabled": true,
+            "Flags": 0,
+            "Attenuation": 5.7279234,
+            "FogMode": "Enabled",
+            "FogStrength": 1,
+            "LightColor": "0.29183,0.57667,0.66047,1",
+            "OnComponentDestroy": null,
+            "OnComponentDisabled": null,
+            "OnComponentEnabled": null,
+            "OnComponentFixedUpdate": null,
+            "OnComponentStart": null,
+            "OnComponentUpdate": null,
+            "Radius": 200,
+            "ShadowBias": 0.0005,
+            "ShadowHardness": 0,
+            "Shadows": false
+          }
+        ],
+        "Children": []
+      },
+      {
+        "__guid": "2e80e4e6-be46-4740-b585-d175a300a962",
+        "__version": 2,
+        "Flags": 0,
+        "Name": "Spray (1)",
+        "Position": "1.88987195,-3.23758911E-07,0",
+        "Rotation": "0,0,0,1",
+        "Scale": "1,1,1",
+        "Tags": "particles",
+        "Enabled": true,
+        "NetworkMode": 2,
+        "NetworkFlags": 0,
+        "NetworkOrphaned": 0,
+        "NetworkTransmit": true,
+        "OwnerTransfer": 1,
+        "Components": [
+          {
+            "__type": "Sandbox.ParticleEffect",
+            "__guid": "2bd4dfbd-68fd-4899-9ea6-4487be1bdf2c",
+            "__enabled": true,
+            "Flags": 0,
+            "__version": 3,
+            "Alpha": {
+              "Type": "Curve",
+              "Evaluation": "Life",
+              "CurveA": [
+                {
+                  "x": 0,
+                  "y": 1,
+                  "in": 0,
+                  "out": 0,
+                  "mode": "Mirrored"
+                },
+                {
+                  "x": 0.48029557,
+                  "y": 1,
+                  "in": 1.5365853,
+                  "out": -1.5365853,
+                  "mode": "Mirrored"
+                },
+                {
+                  "x": 1,
+                  "y": 0,
+                  "in": 1.312303,
+                  "out": -1.312303,
+                  "mode": "Mirrored"
+                }
+              ],
+              "CurveB": [
+                {
+                  "x": 0.5,
+                  "y": 0.5,
+                  "in": 0,
+                  "out": 0,
+                  "mode": "Mirrored"
+                }
+              ]
+            },
+            "ApplyAlpha": true,
+            "ApplyColor": true,
+            "ApplyRotation": false,
+            "ApplyShape": true,
+            "Bounce": 0.3,
+            "Brightness": {
+              "Type": "Curve",
+              "Evaluation": "Life",
+              "CurveA": {
+                "rangey": "0,100",
+                "frames": [
+                  {
+                    "x": 0,
+                    "y": 1,
+                    "in": 2.625,
+                    "out": -2.625,
+                    "mode": "Mirrored"
+                  },
+                  {
+                    "x": 1,
+                    "y": 0,
+                    "in": 0.022727339,
+                    "out": -0.022727339,
+                    "mode": "Mirrored"
+                  }
+                ]
+              },
+              "CurveB": [
+                {
+                  "x": 0.5,
+                  "y": 0.5,
+                  "in": 0,
+                  "out": 0,
+                  "mode": "Mirrored"
+                }
+              ]
+            },
+            "Bumpiness": 0,
+            "Collision": false,
+            "CollisionIgnore": null,
+            "CollisionPrefab": null,
+            "CollisionPrefabAlign": false,
+            "CollisionPrefabChance": 1,
+            "CollisionPrefabRotation": 0,
+            "CollisionRadius": 1,
+            "ConstantMovement": {
+              "X": 0,
+              "Y": 0,
+              "Z": 0
+            },
+            "Damping": 5,
+            "DieOnCollisionChance": 0.3,
+            "FollowerPrefab": null,
+            "FollowerPrefabChance": 1,
+            "FollowerPrefabKill": true,
+            "Force": true,
+            "ForceDirection": "0,0,-100",
+            "ForceScale": 1,
+            "ForceSpace": "World",
+            "Friction": 0.2,
+            "Gradient": {
+              "Type": "Range",
+              "Evaluation": "Particle",
+              "ConstantA": "0.8132,0.94949,0.97674,1",
+              "ConstantB": "0.2,0.6,1,1"
+            },
+            "InitialVelocity": {
+              "X": 0,
+              "Y": 0,
+              "Z": 0
+            },
+            "Lifetime": {
+              "Type": "Range",
+              "Evaluation": "Seed",
+              "Constants": "0.100000001,0.200000003,0,0"
+            },
+            "LocalSpace": {
+              "Type": "Curve",
+              "Evaluation": "Life",
+              "CurveA": {
+                "rangex": "0,0.423437506",
+                "frames": [
+                  {
+                    "x": 0,
+                    "y": 1,
+                    "in": 2.4038465,
+                    "out": -2.4038465,
+                    "mode": "Mirrored"
+                  },
+                  {
+                    "x": 1,
+                    "y": 0,
+                    "in": 0,
+                    "out": 0,
+                    "mode": "Mirrored"
+                  }
+                ]
+              },
+              "CurveB": [
+                {
+                  "x": 0.5,
+                  "y": 0.5,
+                  "in": 0,
+                  "out": 0,
+                  "mode": "Mirrored"
+                }
+              ]
+            },
+            "MaxParticles": 5000,
+            "OnComponentDestroy": null,
+            "OnComponentDisabled": null,
+            "OnComponentEnabled": null,
+            "OnComponentFixedUpdate": null,
+            "OnComponentStart": null,
+            "OnComponentUpdate": null,
+            "OnParticleCreated": null,
+            "OnParticleDestroyed": null,
+            "OrbitalForce": {
+              "X": 0,
+              "Y": 0,
+              "Z": 0
+            },
+            "OrbitalPull": 0,
+            "PerParticleTimeScale": 1,
+            "Pitch": 0,
+            "PreWarm": 0,
+            "PushStrength": 0,
+            "Roll": 0,
+            "Scale": {
+              "Type": "CurveRange",
+              "Evaluation": "Life",
+              "CurveA": {
+                "rangey": "0,6",
+                "frames": [
+                  {
+                    "x": 0,
+                    "y": 0.185484,
+                    "in": 7.7882873E-07,
+                    "out": -7.7882873E-07,
+                    "mode": "Mirrored"
+                  },
+                  {
+                    "x": 0.1880109,
+                    "y": 0.07718992,
+                    "in": 0,
+                    "out": 0,
+                    "mode": "Mirrored"
+                  },
+                  {
+                    "x": 1,
+                    "y": 0,
+                    "in": 0,
+                    "out": 0,
+                    "mode": "Mirrored"
+                  }
+                ]
+              },
+              "CurveB": {
+                "rangey": "0,4",
+                "frames": [
+                  {
+                    "x": 0,
+                    "y": 0.05645162,
+                    "in": 0.35714334,
+                    "out": -0.35714334,
+                    "mode": "Mirrored"
+                  },
+                  {
+                    "x": 0.1893733,
+                    "y": 0.03729546,
+                    "in": 0,
+                    "out": 0,
+                    "mode": "Mirrored"
+                  },
+                  {
+                    "x": 1,
+                    "y": 0,
+                    "in": 0,
+                    "out": 0,
+                    "mode": "Mirrored"
+                  }
+                ]
+              }
+            },
+            "SequenceId": 0,
+            "SequenceSpeed": 1,
+            "SequenceTime": 1,
+            "SheetSequence": false,
+            "SnapToFrame": false,
+            "StartDelay": 0,
+            "StartVelocity": {
+              "Type": "Range",
+              "Evaluation": "Seed",
+              "Constants": "50,100,0,0"
+            },
+            "Stretch": 0,
+            "TimeScale": 1,
+            "Timing": "GameTime",
+            "Tint": "1,1,1,1",
+            "UsePrefabFeature": false,
+            "Yaw": {
+              "Type": "Range",
+              "Evaluation": "Seed",
+              "Constants": "0,360,0,0"
+            }
+          },
+          {
+            "__type": "Sandbox.ParticleSpriteRenderer",
+            "__guid": "833a095d-6564-4fe4-ade9-26d775e2d85c",
+            "__enabled": true,
+            "Flags": 0,
+            "__version": 2,
+            "Additive": true,
+            "Alignment": "LookAtCamera",
+            "BlurAmount": 1,
+            "BlurOpacity": 1,
+            "BlurSpacing": 1,
+            "DepthFeather": 0,
+            "FaceVelocity": false,
+            "FogStrength": 1,
+            "LeadingTrail": true,
+            "Lighting": false,
+            "MotionBlur": true,
+            "OnComponentDestroy": null,
+            "OnComponentDisabled": null,
+            "OnComponentEnabled": null,
+            "OnComponentFixedUpdate": null,
+            "OnComponentStart": null,
+            "OnComponentUpdate": null,
+            "Opaque": false,
+            "PlaybackSpeed": 1,
+            "RenderOptions": {
+              "GameLayer": true,
+              "OverlayLayer": false,
+              "BloomLayer": true,
+              "AfterUILayer": false
+            },
+            "RotationOffset": 0,
+            "Scale": 1,
+            "Shadows": false,
+            "SortMode": "Unsorted",
+            "Sprite": {
+              "$compiler": "embed",
+              "$source": null,
+              "data": {
+                "Animations": [
+                  {
+                    "Name": "Default",
+                    "FrameRate": 15,
+                    "Origin": "0.5,0.5",
+                    "LoopMode": "Loop",
+                    "Frames": [
+                      {
+                        "Texture": {
+                          "$compiler": "texture",
+                          "$source": "imagefile",
+                          "data": {
+                            "FilePath": "textures/shapes/triangle1.png",
+                            "MaxSize": 4096,
+                            "ConvertHeightToNormals": false,
+                            "NormalScale": 1,
+                            "Rotate": 0,
+                            "FlipVertical": false,
+                            "FlipHorizontal": false,
+                            "Cropping": {
+                              "Left": 0,
+                              "Top": 0,
+                              "Right": 0,
+                              "Bottom": 0
+                            },
+                            "Padding": {
+                              "Left": 0,
+                              "Top": 0,
+                              "Right": 0,
+                              "Bottom": 0
+                            },
+                            "InvertColor": false,
+                            "Tint": "1,1,1,1",
+                            "Blur": 0,
+                            "Sharpen": 0,
+                            "Brightness": 1,
+                            "Contrast": 1,
+                            "Saturation": 1,
+                            "Hue": 0,
+                            "Colorize": false,
+                            "TargetColor": "0,1,0,1",
+                            "CacheToDisk": true
+                          },
+                          "compiled": "textures/generated/imagefile/760a6cd994d08dc9.vtex"
+                        },
+                        "BroadcastMessages": []
+                      }
+                    ]
+                  }
+                ],
+                "__references": null
+              },
+              "compiled": null
+            },
+            "StartingAnimationName": "Default",
+            "TextureFilter": "Bilinear"
+          },
+          {
+            "__type": "Sandbox.ParticleSphereEmitter",
+            "__guid": "fb5ca329-8929-4245-a39b-928175340c77",
+            "__enabled": true,
+            "Flags": 0,
+            "Burst": 0,
+            "Delay": 0,
+            "DestroyOnEnd": false,
+            "Duration": 1,
+            "Loop": true,
+            "OnComponentDestroy": null,
+            "OnComponentDisabled": null,
+            "OnComponentEnabled": null,
+            "OnComponentFixedUpdate": null,
+            "OnComponentStart": null,
+            "OnComponentUpdate": null,
+            "OnEdge": false,
+            "Radius": 1,
+            "Rate": 20,
+            "RateOverDistance": 0,
+            "Velocity": 5
+          },
+          {
+            "__type": "TemporaryEffect",
+            "__guid": "1a597902-4e68-4c61-aaa6-6bc63d36a4bd",
+            "__enabled": true,
+            "Flags": 0,
+            "BecomeOrphan": true,
+            "DestroyAfterSeconds": 1,
+            "OnComponentDestroy": null,
+            "OnComponentDisabled": null,
+            "OnComponentEnabled": null,
+            "OnComponentFixedUpdate": null,
+            "OnComponentStart": null,
+            "OnComponentUpdate": null,
+            "WaitForChildEffects": true
+          }
+        ],
+        "Children": []
+      }
+    ],
+    "__properties": {
+      "NetworkInterpolation": true,
+      "TimeScale": 1,
+      "WantsSystemScene": true,
+      "Metadata": {},
+      "NavMesh": {
+        "Enabled": false,
+        "IncludeStaticBodies": true,
+        "IncludeKeyframedBodies": true,
+        "EditorAutoUpdate": false,
+        "AgentHeight": 64,
+        "AgentRadius": 16,
+        "AgentStepSize": 18,
+        "AgentMaxSlope": 40,
+        "ExcludedBodies": "",
+        "IncludedBodies": "",
+        "DeferGeneration": false,
+        "CustomBounds": false
+      }
+    },
+    "__variables": []
+  },
+  "ResourceVersion": 2,
+  "ShowInMenu": false,
+  "MenuPath": null,
+  "MenuIcon": null,
+  "DontBreakAsTemplate": false,
+  "__references": [],
+  "__version": 2
+}

--- a/Assets/prefabs/weapons/physgun/effects/unfreeze.prefab
+++ b/Assets/prefabs/weapons/physgun/effects/unfreeze.prefab
@@ -1,0 +1,961 @@
+{
+  "RootObject": {
+    "__guid": "e5cf5f34-17b5-4e70-b8db-d7f54a8ad61d",
+    "__version": 1,
+    "Flags": 0,
+    "Name": "unfreeze",
+    "Position": "0,0,0",
+    "Rotation": "0,0,0,1",
+    "Scale": "1,1,1",
+    "Tags": "",
+    "Enabled": true,
+    "NetworkMode": 2,
+    "NetworkInterpolation": true,
+    "NetworkOrphaned": 0,
+    "NetworkTransmit": true,
+    "OwnerTransfer": 1,
+    "Components": [
+      {
+        "__type": "TemporaryEffect",
+        "__guid": "efd434b8-3b7f-4dbf-be75-086c2abd0203",
+        "__enabled": true,
+        "BecomeOrphan": false,
+        "DestroyAfterSeconds": 1,
+        "OnComponentDestroy": null,
+        "OnComponentDisabled": null,
+        "OnComponentEnabled": null,
+        "OnComponentFixedUpdate": null,
+        "OnComponentStart": null,
+        "OnComponentUpdate": null,
+        "WaitForChildEffects": true
+      },
+      {
+        "__type": "Sandbox.SoundPointComponent",
+        "__guid": "3d53156e-8349-4719-a1f9-797f3a3886ca",
+        "__enabled": true,
+        "Distance": 512,
+        "DistanceAttenuation": false,
+        "DistanceAttenuationOverride": false,
+        "Falloff": [
+          {
+            "x": 0,
+            "y": 1,
+            "in": 3.1415927,
+            "out": -3.1415927,
+            "mode": "Mirrored"
+          },
+          {
+            "x": 1,
+            "y": 0,
+            "in": 0,
+            "out": 0,
+            "mode": "Mirrored"
+          }
+        ],
+        "Force2d": false,
+        "MaxRepeatTime": 1,
+        "MinRepeatTime": 1,
+        "Occlusion": false,
+        "OcclusionOverride": false,
+        "OcclusionRadius": 32,
+        "OnComponentDestroy": null,
+        "OnComponentDisabled": null,
+        "OnComponentEnabled": null,
+        "OnComponentFixedUpdate": null,
+        "OnComponentStart": null,
+        "OnComponentUpdate": null,
+        "Pitch": 1,
+        "PlayOnStart": true,
+        "ReflectionOverride": false,
+        "Reflections": false,
+        "Repeat": false,
+        "SoundEvent": "weapons/physgun/sounds/physgun.unfreeze.1.sound",
+        "SoundOverride": false,
+        "StopOnNew": false,
+        "TargetMixer": {
+          "Name": "unknown",
+          "Id": "00000000-0000-0000-0000-000000000000"
+        },
+        "Volume": 1
+      }
+    ],
+    "Children": [
+      {
+        "__guid": "d9a12be7-ae8f-4eff-8d9f-f4fc57d3545b",
+        "__version": 1,
+        "Flags": 0,
+        "Name": "Burst",
+        "Position": "0,0,0.8528237",
+        "Rotation": "0,0,0,1",
+        "Scale": "1,1,1",
+        "Tags": "particles",
+        "Enabled": true,
+        "NetworkMode": 2,
+        "NetworkInterpolation": true,
+        "NetworkOrphaned": 0,
+        "NetworkTransmit": true,
+        "OwnerTransfer": 1,
+        "Components": [
+          {
+            "__type": "Sandbox.ParticleEffect",
+            "__guid": "e6218df3-684f-4a4a-a6fe-1114daf080db",
+            "__enabled": true,
+            "__version": 3,
+            "Alpha": {
+              "Type": "CurveRange",
+              "Evaluation": "Life",
+              "CurveA": [
+                {
+                  "x": 0,
+                  "y": 0,
+                  "in": -0.97142893,
+                  "out": 0.97142893,
+                  "mode": "Mirrored"
+                },
+                {
+                  "x": 0.11444142,
+                  "y": 1,
+                  "in": 0,
+                  "out": 0,
+                  "mode": "Mirrored"
+                },
+                {
+                  "x": 1,
+                  "y": 0,
+                  "in": 6.0909085,
+                  "out": -6.0909085,
+                  "mode": "Mirrored"
+                }
+              ],
+              "CurveB": [
+                {
+                  "x": 0,
+                  "y": 0,
+                  "in": -0.91891897,
+                  "out": 0.91891897,
+                  "mode": "Mirrored"
+                },
+                {
+                  "x": 0.073569484,
+                  "y": 1,
+                  "in": 0,
+                  "out": 0,
+                  "mode": "Mirrored"
+                },
+                {
+                  "x": 1,
+                  "y": 0,
+                  "in": 3.3199997,
+                  "out": -3.3199997,
+                  "mode": "Mirrored"
+                }
+              ]
+            },
+            "ApplyAlpha": true,
+            "ApplyColor": true,
+            "ApplyRotation": true,
+            "ApplyShape": true,
+            "Bounce": 1,
+            "Brightness": {
+              "Type": "CurveRange",
+              "Evaluation": "Life",
+              "CurveA": {
+                "rangey": "0,100",
+                "frames": [
+                  {
+                    "x": 0,
+                    "y": 0.27822578,
+                    "in": 0.16098209,
+                    "out": -0.16098209,
+                    "mode": "Mirrored"
+                  },
+                  {
+                    "x": 1,
+                    "y": 0,
+                    "in": 0.3356071,
+                    "out": -0.3356071,
+                    "mode": "Mirrored"
+                  }
+                ]
+              },
+              "CurveB": {
+                "rangey": "0,100",
+                "frames": [
+                  {
+                    "x": 0,
+                    "y": 0.9395161,
+                    "in": 0.100278184,
+                    "out": -0.100278184,
+                    "mode": "Mirrored"
+                  },
+                  {
+                    "x": 1,
+                    "y": 0.58870965,
+                    "in": 0.39361706,
+                    "out": -0.39361706,
+                    "mode": "Mirrored"
+                  }
+                ]
+              }
+            },
+            "Bumpiness": 0,
+            "Collision": false,
+            "CollisionIgnore": null,
+            "CollisionPrefab": null,
+            "CollisionPrefabAlign": false,
+            "CollisionPrefabChance": 1,
+            "CollisionPrefabRotation": 0,
+            "CollisionRadius": 1,
+            "ConstantMovement": {
+              "X": {
+                "Type": "Range",
+                "Evaluation": "Seed",
+                "Constants": "0,0,0,0"
+              },
+              "Y": 0,
+              "Z": {
+                "Type": "Range",
+                "Evaluation": "Seed",
+                "Constants": "5,10,0,0"
+              }
+            },
+            "Damping": 2,
+            "DieOnCollisionChance": 0,
+            "FollowerPrefab": null,
+            "FollowerPrefabChance": 1,
+            "FollowerPrefabKill": true,
+            "Force": false,
+            "ForceDirection": "0,0,-800",
+            "ForceScale": 1,
+            "ForceSpace": "World",
+            "Friction": 1,
+            "Gradient": {
+              "Type": "Range",
+              "Evaluation": "Particle",
+              "GradientA": {
+                "blend": "Linear",
+                "color": [
+                  {
+                    "t": 0.5,
+                    "c": "1,1,1,1"
+                  }
+                ],
+                "alpha": []
+              },
+              "GradientB": {
+                "blend": "Linear",
+                "color": [
+                  {
+                    "t": 0.5,
+                    "c": "1,1,1,1"
+                  }
+                ],
+                "alpha": []
+              },
+              "ConstantA": "0.72558,0.96798,1,1",
+              "ConstantB": "0.09661,0.8453,0.94419,1"
+            },
+            "InitialVelocity": {
+              "X": 0,
+              "Y": 0,
+              "Z": 0
+            },
+            "Lifetime": {
+              "Type": "Range",
+              "Evaluation": "Seed",
+              "Constants": "0.1,0.15,0,0"
+            },
+            "LocalSpace": 0,
+            "MaxParticles": 5000,
+            "OnComponentDestroy": null,
+            "OnComponentDisabled": null,
+            "OnComponentEnabled": null,
+            "OnComponentFixedUpdate": null,
+            "OnComponentStart": null,
+            "OnComponentUpdate": null,
+            "OnParticleCreated": null,
+            "OnParticleDestroyed": null,
+            "OrbitalForce": {
+              "X": 0,
+              "Y": 0,
+              "Z": 0
+            },
+            "OrbitalPull": 0,
+            "PerParticleTimeScale": 1,
+            "Pitch": {
+              "Type": "Range",
+              "Evaluation": "Seed",
+              "Constants": "0,360,0,0"
+            },
+            "PreWarm": 0,
+            "PushStrength": 0,
+            "Roll": {
+              "Type": "Range",
+              "Evaluation": "Seed",
+              "Constants": "0,360,0,0"
+            },
+            "Scale": {
+              "Type": "CurveRange",
+              "Evaluation": "Life",
+              "CurveA": {
+                "rangey": "0,80",
+                "frames": [
+                  {
+                    "x": 0,
+                    "y": 0.20967746,
+                    "in": -0.19718336,
+                    "out": 0.19718336,
+                    "mode": "Mirrored"
+                  },
+                  {
+                    "x": 1,
+                    "y": 0.2298388,
+                    "in": 0.1910111,
+                    "out": -0.1910111,
+                    "mode": "Mirrored"
+                  }
+                ]
+              },
+              "CurveB": {
+                "rangey": "0,61",
+                "frames": [
+                  {
+                    "x": 0,
+                    "y": 0.07661294,
+                    "in": -0.40625045,
+                    "out": 0.40625045,
+                    "mode": "Mirrored"
+                  },
+                  {
+                    "x": 1,
+                    "y": 0.032258082,
+                    "in": 0.061538555,
+                    "out": -0.061538555,
+                    "mode": "Mirrored"
+                  }
+                ]
+              }
+            },
+            "SequenceId": 0,
+            "SequenceSpeed": 1,
+            "SequenceTime": 1,
+            "SheetSequence": false,
+            "StartDelay": {
+              "Type": "Range",
+              "Evaluation": "Seed",
+              "Constants": "0,0.1,0,0"
+            },
+            "StartVelocity": {
+              "Type": "Range",
+              "Evaluation": "Seed",
+              "Constants": "10,50,0,0"
+            },
+            "Stretch": 0,
+            "TimeScale": 1,
+            "Timing": "GameTime",
+            "Tint": "0.7907,1,0.90233,1",
+            "UsePrefabFeature": false,
+            "Yaw": {
+              "Type": "Range",
+              "Evaluation": "Seed",
+              "Constants": "0,360,0,0"
+            }
+          },
+          {
+            "__type": "Sandbox.ParticleSpriteRenderer",
+            "__guid": "19d464f6-8041-4eb8-bc4e-7f28a1bcea6f",
+            "__enabled": true,
+            "__version": 2,
+            "Additive": true,
+            "Alignment": "LookAtCamera",
+            "BlurAmount": 0.5,
+            "BlurOpacity": 0.91,
+            "BlurSpacing": 0.73,
+            "DepthFeather": 1.946472,
+            "FaceVelocity": false,
+            "FogStrength": 1,
+            "LeadingTrail": true,
+            "Lighting": false,
+            "MotionBlur": false,
+            "OnComponentDestroy": null,
+            "OnComponentDisabled": null,
+            "OnComponentEnabled": null,
+            "OnComponentFixedUpdate": null,
+            "OnComponentStart": null,
+            "OnComponentUpdate": null,
+            "Opaque": false,
+            "PlaybackSpeed": 1,
+            "RenderOptions": {
+              "GameLayer": true,
+              "OverlayLayer": false,
+              "BloomLayer": true,
+              "AfterUILayer": false
+            },
+            "RotationOffset": 0,
+            "Scale": 1,
+            "Shadows": false,
+            "SortMode": "Unsorted",
+            "Sprite": {
+              "$compiler": "embed",
+              "$source": null,
+              "data": {
+                "Animations": [
+                  {
+                    "Name": "Default",
+                    "FrameRate": 15,
+                    "Origin": "0.5,0.5",
+                    "LoopMode": "Loop",
+                    "Frames": [
+                      {
+                        "Texture": {
+                          "$compiler": "texture",
+                          "$source": "imagefile",
+                          "data": {
+                            "FilePath": "textures/beams/lightning.png",
+                            "MaxSize": 4096,
+                            "ConvertHeightToNormals": false,
+                            "NormalScale": 1,
+                            "Rotate": 0,
+                            "FlipVertical": false,
+                            "FlipHorizontal": false,
+                            "Cropping": {
+                              "Left": 0,
+                              "Top": 0,
+                              "Right": 0,
+                              "Bottom": 0
+                            },
+                            "Padding": {
+                              "Left": 0,
+                              "Top": 0,
+                              "Right": 0,
+                              "Bottom": 0
+                            },
+                            "InvertColor": false,
+                            "Tint": "1,1,1,1",
+                            "Blur": 0,
+                            "Sharpen": 0,
+                            "Brightness": 1,
+                            "Contrast": 1,
+                            "Saturation": 1,
+                            "Hue": 0,
+                            "Colorize": false,
+                            "TargetColor": "0,1,0,1",
+                            "CacheToDisk": true
+                          },
+                          "compiled": null
+                        },
+                        "BroadcastMessages": []
+                      }
+                    ]
+                  }
+                ],
+                "__references": null
+              },
+              "compiled": null
+            },
+            "StartingAnimationName": "Default",
+            "TextureFilter": "Bilinear"
+          },
+          {
+            "__type": "Sandbox.ParticleModelEmitter",
+            "__guid": "75f19837-721d-4a73-8988-70a21972aa3e",
+            "__enabled": true,
+            "Burst": 30,
+            "Delay": 0,
+            "DestroyOnEnd": false,
+            "Duration": 1,
+            "Loop": false,
+            "OnComponentDestroy": null,
+            "OnComponentDisabled": null,
+            "OnComponentEnabled": null,
+            "OnComponentFixedUpdate": null,
+            "OnComponentStart": null,
+            "OnComponentUpdate": null,
+            "OnEdge": true,
+            "Rate": 0,
+            "RateOverDistance": 0,
+            "Target": {
+              "_type": "gameobject",
+              "go": "474cbd24-69b5-4544-b895-5d00f4267072"
+            }
+          },
+          {
+            "__type": "Sandbox.ParticleLightRenderer",
+            "__guid": "fe319829-5fe7-447f-9175-55c4377571bc",
+            "__enabled": true,
+            "Attenuation": 4,
+            "Brightness": 1,
+            "CastShadows": false,
+            "LightColor": {
+              "Type": "Constant",
+              "Evaluation": "Life",
+              "GradientA": {
+                "blend": "Linear",
+                "color": [
+                  {
+                    "t": 0.5,
+                    "c": "1,1,1,1"
+                  }
+                ],
+                "alpha": []
+              },
+              "GradientB": {
+                "blend": "Linear",
+                "color": [
+                  {
+                    "t": 0.5,
+                    "c": "1,1,1,1"
+                  }
+                ],
+                "alpha": []
+              },
+              "ConstantA": "1,1,1,1",
+              "ConstantB": "1,1,1,1"
+            },
+            "MaximumLights": 8,
+            "OnComponentDestroy": null,
+            "OnComponentDisabled": null,
+            "OnComponentEnabled": null,
+            "OnComponentFixedUpdate": null,
+            "OnComponentStart": null,
+            "OnComponentUpdate": null,
+            "Ratio": 1,
+            "Scale": 8,
+            "UseParticleColor": true
+          }
+        ],
+        "Children": []
+      },
+      {
+        "__guid": "20362926-3f6f-471c-b4f0-e9f5690b06df",
+        "__version": 1,
+        "Flags": 0,
+        "Name": "Bits",
+        "Position": "0,0,0.8528237",
+        "Rotation": "0,0,0,1",
+        "Scale": "1,1,1",
+        "Tags": "particles",
+        "Enabled": true,
+        "NetworkMode": 2,
+        "NetworkInterpolation": true,
+        "NetworkOrphaned": 0,
+        "NetworkTransmit": true,
+        "OwnerTransfer": 1,
+        "Components": [
+          {
+            "__type": "Sandbox.ParticleEffect",
+            "__guid": "fc0dbbc6-8b27-415b-8909-152d0c248376",
+            "__enabled": true,
+            "__version": 3,
+            "Alpha": {
+              "Type": "Curve",
+              "Evaluation": "Life",
+              "CurveA": [
+                {
+                  "x": 0,
+                  "y": 1,
+                  "in": 3.1415927,
+                  "out": -3.1415927,
+                  "mode": "Mirrored"
+                },
+                {
+                  "x": 1,
+                  "y": 0,
+                  "in": -0,
+                  "out": -0,
+                  "mode": "Mirrored"
+                }
+              ],
+              "CurveB": [
+                {
+                  "x": 0,
+                  "y": 0,
+                  "in": -0.91891897,
+                  "out": 0.91891897,
+                  "mode": "Mirrored"
+                },
+                {
+                  "x": 0.10626703,
+                  "y": 0.6935484,
+                  "in": 0,
+                  "out": 0,
+                  "mode": "Mirrored"
+                },
+                {
+                  "x": 0.115803815,
+                  "y": 1.0000556,
+                  "in": 0,
+                  "out": 0,
+                  "mode": "Mirrored"
+                }
+              ]
+            },
+            "ApplyAlpha": true,
+            "ApplyColor": true,
+            "ApplyRotation": true,
+            "ApplyShape": true,
+            "Bounce": 1,
+            "Brightness": {
+              "Type": "CurveRange",
+              "Evaluation": "Life",
+              "CurveA": {
+                "rangey": "0,100",
+                "frames": [
+                  {
+                    "x": 0,
+                    "y": 0.733871,
+                    "in": 0.16098209,
+                    "out": -0.16098209,
+                    "mode": "Mirrored"
+                  },
+                  {
+                    "x": 1,
+                    "y": 0,
+                    "in": 0.3356071,
+                    "out": -0.3356071,
+                    "mode": "Mirrored"
+                  }
+                ]
+              },
+              "CurveB": {
+                "rangey": "0,100",
+                "frames": [
+                  {
+                    "x": 0,
+                    "y": 0.9395161,
+                    "in": 0.100278184,
+                    "out": -0.100278184,
+                    "mode": "Mirrored"
+                  },
+                  {
+                    "x": 1,
+                    "y": 0,
+                    "in": 0.39361706,
+                    "out": -0.39361706,
+                    "mode": "Mirrored"
+                  }
+                ]
+              }
+            },
+            "Bumpiness": 0,
+            "Collision": false,
+            "CollisionIgnore": null,
+            "CollisionPrefab": null,
+            "CollisionPrefabAlign": false,
+            "CollisionPrefabChance": 1,
+            "CollisionPrefabRotation": 0,
+            "CollisionRadius": 1,
+            "ConstantMovement": {
+              "X": {
+                "Type": "Range",
+                "Evaluation": "Seed",
+                "Constants": "0,0,0,0"
+              },
+              "Y": 0,
+              "Z": {
+                "Type": "CurveRange",
+                "Evaluation": "Life",
+                "CurveA": {
+                  "rangey": "0,10",
+                  "frames": [
+                    {
+                      "x": 0,
+                      "y": 0.07661295,
+                      "in": 0,
+                      "out": 0,
+                      "mode": "Mirrored"
+                    },
+                    {
+                      "x": 0.97002727,
+                      "y": 0,
+                      "in": 0,
+                      "out": 0,
+                      "mode": "Mirrored"
+                    }
+                  ]
+                },
+                "CurveB": {
+                  "rangey": "0,10",
+                  "frames": [
+                    {
+                      "x": 0,
+                      "y": 0.39112908,
+                      "in": 0,
+                      "out": 0,
+                      "mode": "Mirrored"
+                    },
+                    {
+                      "x": 1,
+                      "y": 0,
+                      "in": 0,
+                      "out": 0,
+                      "mode": "Mirrored"
+                    }
+                  ]
+                }
+              }
+            },
+            "Damping": 0,
+            "DieOnCollisionChance": 0,
+            "FollowerPrefab": null,
+            "FollowerPrefabChance": 1,
+            "FollowerPrefabKill": true,
+            "Force": false,
+            "ForceDirection": "0,0,200",
+            "ForceScale": 1,
+            "ForceSpace": "World",
+            "Friction": 1,
+            "Gradient": {
+              "Type": "Range",
+              "Evaluation": "Particle",
+              "GradientA": {
+                "blend": "Linear",
+                "color": [
+                  {
+                    "t": 0.5,
+                    "c": "1,1,1,1"
+                  }
+                ],
+                "alpha": []
+              },
+              "GradientB": {
+                "blend": "Linear",
+                "color": [
+                  {
+                    "t": 0.5,
+                    "c": "1,1,1,1"
+                  }
+                ],
+                "alpha": []
+              },
+              "ConstantA": "0.72558,0.96798,1,1",
+              "ConstantB": "0.09661,0.8453,0.94419,1"
+            },
+            "InitialVelocity": {
+              "X": 0,
+              "Y": 0,
+              "Z": 0
+            },
+            "Lifetime": {
+              "Type": "Range",
+              "Evaluation": "Seed",
+              "Constants": "1,2,0,0"
+            },
+            "LocalSpace": 0,
+            "MaxParticles": 5000,
+            "OnComponentDestroy": null,
+            "OnComponentDisabled": null,
+            "OnComponentEnabled": null,
+            "OnComponentFixedUpdate": null,
+            "OnComponentStart": null,
+            "OnComponentUpdate": null,
+            "OnParticleCreated": null,
+            "OnParticleDestroyed": null,
+            "OrbitalForce": {
+              "X": 0,
+              "Y": 0,
+              "Z": 0
+            },
+            "OrbitalPull": 0,
+            "PerParticleTimeScale": 1,
+            "Pitch": {
+              "Type": "Range",
+              "Evaluation": "Seed",
+              "Constants": "0,360,0,0"
+            },
+            "PreWarm": 0,
+            "PushStrength": 0,
+            "Roll": {
+              "Type": "Range",
+              "Evaluation": "Seed",
+              "Constants": "0,360,0,0"
+            },
+            "Scale": {
+              "Type": "Range",
+              "Evaluation": "Seed",
+              "Constants": "0.1,0.2,0,0"
+            },
+            "SequenceId": 0,
+            "SequenceSpeed": 1,
+            "SequenceTime": 1,
+            "SheetSequence": false,
+            "StartDelay": {
+              "Type": "Range",
+              "Evaluation": "Seed",
+              "Constants": "0,0.1,0,0"
+            },
+            "StartVelocity": {
+              "Type": "Range",
+              "Evaluation": "Seed",
+              "Constants": "0,0,0,0"
+            },
+            "Stretch": 0,
+            "TimeScale": 1,
+            "Timing": "GameTime",
+            "Tint": "0.7907,0.98605,1,1",
+            "UsePrefabFeature": false,
+            "Yaw": {
+              "Type": "Range",
+              "Evaluation": "Seed",
+              "Constants": "0,360,0,0"
+            }
+          },
+          {
+            "__type": "Sandbox.ParticleSpriteRenderer",
+            "__guid": "9690bb90-e03d-4439-8ed6-b5849fd0c0f4",
+            "__enabled": true,
+            "__version": 2,
+            "Additive": true,
+            "Alignment": "LookAtCamera",
+            "BlurAmount": 1,
+            "BlurOpacity": 1,
+            "BlurSpacing": 1,
+            "DepthFeather": 0,
+            "FaceVelocity": false,
+            "FogStrength": 1,
+            "LeadingTrail": true,
+            "Lighting": false,
+            "MotionBlur": false,
+            "OnComponentDestroy": null,
+            "OnComponentDisabled": null,
+            "OnComponentEnabled": null,
+            "OnComponentFixedUpdate": null,
+            "OnComponentStart": null,
+            "OnComponentUpdate": null,
+            "Opaque": false,
+            "PlaybackSpeed": 1,
+            "RenderOptions": {
+              "GameLayer": true,
+              "OverlayLayer": false,
+              "BloomLayer": false,
+              "AfterUILayer": false
+            },
+            "RotationOffset": 0,
+            "Scale": 1.0413625,
+            "Shadows": false,
+            "SortMode": "Unsorted",
+            "Sprite": {
+              "$compiler": "embed",
+              "$source": null,
+              "data": {
+                "Animations": [
+                  {
+                    "Name": "Default",
+                    "FrameRate": 15,
+                    "Origin": "0.5,0.5",
+                    "LoopMode": "Loop",
+                    "Frames": [
+                      {
+                        "Texture": "textures/particles/base_sprite.vtex",
+                        "BroadcastMessages": []
+                      }
+                    ]
+                  }
+                ],
+                "__references": null
+              },
+              "compiled": null
+            },
+            "StartingAnimationName": "Default",
+            "TextureFilter": "Bilinear"
+          },
+          {
+            "__type": "Sandbox.ParticleModelEmitter",
+            "__guid": "1d35bc18-4552-4e13-871f-1909db4523b8",
+            "__enabled": true,
+            "Burst": 30,
+            "Delay": 0,
+            "DestroyOnEnd": false,
+            "Duration": 1,
+            "Loop": false,
+            "OnComponentDestroy": null,
+            "OnComponentDisabled": null,
+            "OnComponentEnabled": null,
+            "OnComponentFixedUpdate": null,
+            "OnComponentStart": null,
+            "OnComponentUpdate": null,
+            "OnEdge": true,
+            "Rate": 0,
+            "RateOverDistance": 0,
+            "Target": {
+              "_type": "gameobject",
+              "go": "474cbd24-69b5-4544-b895-5d00f4267072"
+            }
+          }
+        ],
+        "Children": []
+      },
+      {
+        "__guid": "474cbd24-69b5-4544-b895-5d00f4267072",
+        "__version": 1,
+        "Flags": 2048,
+        "Name": "Cube",
+        "Position": "0,0,63.26761",
+        "Rotation": "0,0,0,1",
+        "Scale": "1,1,1",
+        "Tags": "",
+        "Enabled": true,
+        "NetworkMode": 2,
+        "NetworkInterpolation": true,
+        "NetworkOrphaned": 0,
+        "NetworkTransmit": true,
+        "OwnerTransfer": 1,
+        "Components": [
+          {
+            "__type": "Sandbox.ModelRenderer",
+            "__guid": "2312c690-e7fc-4a98-bf63-3082c6fa519c",
+            "__enabled": true,
+            "BodyGroups": 18446744073709551615,
+            "CreateAttachments": false,
+            "LodOverride": null,
+            "MaterialGroup": null,
+            "MaterialOverride": null,
+            "Materials": null,
+            "Model": "models/dev/error.vmdl",
+            "OnComponentDestroy": null,
+            "OnComponentDisabled": null,
+            "OnComponentEnabled": null,
+            "OnComponentFixedUpdate": null,
+            "OnComponentStart": null,
+            "OnComponentUpdate": null,
+            "RenderOptions": {
+              "GameLayer": true,
+              "OverlayLayer": false,
+              "BloomLayer": false,
+              "AfterUILayer": false
+            },
+            "RenderType": "On",
+            "Tint": "0.24186,0.24186,0.24186,1"
+          }
+        ],
+        "Children": []
+      }
+    ],
+    "__properties": {
+      "NetworkInterpolation": true,
+      "TimeScale": 1,
+      "WantsSystemScene": true,
+      "Metadata": {},
+      "NavMesh": {
+        "Enabled": false,
+        "IncludeStaticBodies": true,
+        "IncludeKeyframedBodies": true,
+        "EditorAutoUpdate": true,
+        "AgentHeight": 64,
+        "AgentRadius": 16,
+        "AgentStepSize": 18,
+        "AgentMaxSlope": 40,
+        "ExcludedBodies": "",
+        "IncludedBodies": ""
+      }
+    },
+    "__variables": []
+  },
+  "ResourceVersion": 2,
+  "ShowInMenu": false,
+  "MenuPath": null,
+  "MenuIcon": null,
+  "DontBreakAsTemplate": false,
+  "__references": [],
+  "__version": 2
+}

--- a/Assets/prefabs/weapons/physgun/effects/wm-glow.prefab
+++ b/Assets/prefabs/weapons/physgun/effects/wm-glow.prefab
@@ -1,0 +1,345 @@
+{
+  "RootObject": {
+    "__guid": "e5cf5f34-17b5-4e70-b8db-d7f54a8ad61d",
+    "__version": 1,
+    "Flags": 0,
+    "Name": "wm-glow",
+    "Position": "0,0,0",
+    "Rotation": "0,0,0,1",
+    "Scale": "1,1,1",
+    "Tags": "",
+    "Enabled": true,
+    "NetworkMode": 2,
+    "NetworkInterpolation": true,
+    "NetworkOrphaned": 0,
+    "NetworkTransmit": true,
+    "OwnerTransfer": 1,
+    "Components": [],
+    "Children": [
+      {
+        "__guid": "3c06d747-a92f-49b3-9749-0902446440a0",
+        "__version": 1,
+        "Flags": 0,
+        "Name": "Point Light",
+        "Position": "7.243077,0,0",
+        "Rotation": "0,0,0,1",
+        "Scale": "1,1,1",
+        "Tags": "light_point,light",
+        "Enabled": true,
+        "NetworkMode": 2,
+        "NetworkInterpolation": true,
+        "NetworkOrphaned": 0,
+        "NetworkTransmit": true,
+        "OwnerTransfer": 1,
+        "Components": [
+          {
+            "__type": "Sandbox.PointLight",
+            "__guid": "1eade6ef-bca3-4844-967d-98d7e79c224e",
+            "__enabled": true,
+            "Attenuation": 20,
+            "FogMode": "Enabled",
+            "FogStrength": 1,
+            "LightColor": "0.25155,0.67173,0.79535,1",
+            "OnComponentDestroy": null,
+            "OnComponentDisabled": null,
+            "OnComponentEnabled": null,
+            "OnComponentFixedUpdate": null,
+            "OnComponentStart": null,
+            "OnComponentUpdate": null,
+            "Radius": 128,
+            "Shadows": false
+          }
+        ],
+        "Children": []
+      },
+      {
+        "__guid": "14848a05-e916-4b3f-abdf-34cf6ff912c9",
+        "__version": 1,
+        "Flags": 0,
+        "Name": "Burst",
+        "Position": "0,0,0",
+        "Rotation": "0,0,0,1",
+        "Scale": "1,1,1",
+        "Tags": "particles",
+        "Enabled": true,
+        "NetworkMode": 2,
+        "NetworkInterpolation": true,
+        "NetworkOrphaned": 0,
+        "NetworkTransmit": true,
+        "OwnerTransfer": 1,
+        "Components": [
+          {
+            "__type": "Sandbox.ParticleEffect",
+            "__guid": "41ef4816-f57a-420c-bc59-2411a9f5251a",
+            "__enabled": true,
+            "__version": 3,
+            "Alpha": {
+              "Type": "Curve",
+              "Evaluation": "Life",
+              "CurveA": [
+                {
+                  "x": 0,
+                  "y": 0,
+                  "in": 0,
+                  "out": 0,
+                  "mode": "Mirrored"
+                },
+                {
+                  "x": 0.0828125,
+                  "y": 1,
+                  "in": 0,
+                  "out": 0,
+                  "mode": "Mirrored"
+                },
+                {
+                  "x": 0.5,
+                  "y": 1,
+                  "in": 0,
+                  "out": 0,
+                  "mode": "Mirrored"
+                },
+                {
+                  "x": 0.8421875,
+                  "y": 1,
+                  "in": 0,
+                  "out": 0,
+                  "mode": "Mirrored"
+                },
+                {
+                  "x": 1,
+                  "y": 0,
+                  "in": 0,
+                  "out": 0,
+                  "mode": "Mirrored"
+                }
+              ],
+              "CurveB": [
+                {
+                  "x": 0.5,
+                  "y": 0.5,
+                  "in": 0,
+                  "out": 0,
+                  "mode": "Mirrored"
+                }
+              ]
+            },
+            "ApplyAlpha": false,
+            "ApplyColor": true,
+            "ApplyRotation": false,
+            "ApplyShape": true,
+            "Bounce": 1,
+            "Brightness": 2,
+            "Bumpiness": 0,
+            "Collision": false,
+            "CollisionIgnore": null,
+            "CollisionPrefab": null,
+            "CollisionPrefabAlign": false,
+            "CollisionPrefabChance": 1,
+            "CollisionPrefabRotation": 0,
+            "CollisionRadius": 1,
+            "ConstantMovement": {
+              "X": 0,
+              "Y": 0,
+              "Z": 0
+            },
+            "Damping": 0,
+            "DieOnCollisionChance": 0,
+            "FollowerPrefab": null,
+            "FollowerPrefabChance": 1,
+            "FollowerPrefabKill": true,
+            "Force": false,
+            "ForceDirection": "0,0,-800",
+            "ForceScale": 1,
+            "ForceSpace": "World",
+            "Friction": 1,
+            "Gradient": {
+              "Type": "Constant",
+              "Evaluation": "Particle",
+              "GradientA": {
+                "blend": "Linear",
+                "color": [
+                  {
+                    "t": 0.5,
+                    "c": "1,1,1,1"
+                  }
+                ],
+                "alpha": []
+              },
+              "GradientB": {
+                "blend": "Linear",
+                "color": [
+                  {
+                    "t": 0.5,
+                    "c": "1,1,1,1"
+                  }
+                ],
+                "alpha": []
+              },
+              "ConstantA": "1,1,1,1",
+              "ConstantB": "1,1,1,1"
+            },
+            "InitialVelocity": {
+              "X": 0,
+              "Y": 0,
+              "Z": 0
+            },
+            "Lifetime": {
+              "Type": "Range",
+              "Evaluation": "Seed",
+              "Constants": "10,10,0,0"
+            },
+            "LocalSpace": 1,
+            "MaxParticles": 2,
+            "OnComponentDestroy": null,
+            "OnComponentDisabled": null,
+            "OnComponentEnabled": null,
+            "OnComponentFixedUpdate": null,
+            "OnComponentStart": null,
+            "OnComponentUpdate": null,
+            "OnParticleCreated": null,
+            "OnParticleDestroyed": null,
+            "OrbitalForce": {
+              "X": 0,
+              "Y": 0,
+              "Z": 0
+            },
+            "OrbitalPull": 0,
+            "PerParticleTimeScale": 1,
+            "Pitch": 0,
+            "PreWarm": 1,
+            "PushStrength": 0,
+            "Roll": 0,
+            "Scale": 30,
+            "SequenceId": 0,
+            "SequenceSpeed": 1,
+            "SequenceTime": 1,
+            "SheetSequence": false,
+            "StartDelay": 0,
+            "StartVelocity": {
+              "Type": "Range",
+              "Evaluation": "Seed",
+              "Constants": "0,0,0,0"
+            },
+            "Stretch": 0,
+            "TimeScale": 1,
+            "Timing": "GameTime",
+            "Tint": "0.25116,0.72543,1,1",
+            "UsePrefabFeature": false,
+            "Yaw": {
+              "Type": "Range",
+              "Evaluation": "Seed",
+              "Constants": "0,360,0,0"
+            }
+          },
+          {
+            "__type": "Sandbox.ParticleSpriteRenderer",
+            "__guid": "feb67b66-6937-4970-b707-655e5b1eb784",
+            "__enabled": true,
+            "__version": 2,
+            "Additive": true,
+            "Alignment": "LookAtCamera",
+            "BlurAmount": 0.5,
+            "BlurOpacity": 0.91,
+            "BlurSpacing": 0.73,
+            "DepthFeather": 9.621993,
+            "FaceVelocity": false,
+            "FogStrength": 1,
+            "LeadingTrail": true,
+            "Lighting": false,
+            "MotionBlur": false,
+            "OnComponentDestroy": null,
+            "OnComponentDisabled": null,
+            "OnComponentEnabled": null,
+            "OnComponentFixedUpdate": null,
+            "OnComponentStart": null,
+            "OnComponentUpdate": null,
+            "Opaque": false,
+            "PlaybackSpeed": 1,
+            "RenderOptions": {
+              "GameLayer": true,
+              "OverlayLayer": false,
+              "BloomLayer": false,
+              "AfterUILayer": false
+            },
+            "RotationOffset": 0,
+            "Scale": 1,
+            "Shadows": false,
+            "SortMode": "Unsorted",
+            "Sprite": {
+              "$compiler": "embed",
+              "$source": null,
+              "data": {
+                "Animations": [
+                  {
+                    "Name": "Default",
+                    "FrameRate": 15,
+                    "Origin": "0.5,0.5",
+                    "LoopMode": "Loop",
+                    "Frames": [
+                      {
+                        "Texture": "textures/lightcookies/lightcookies_09.vtex",
+                        "BroadcastMessages": []
+                      }
+                    ]
+                  }
+                ],
+                "__references": null
+              },
+              "compiled": null
+            },
+            "StartingAnimationName": "Default",
+            "TextureFilter": "Bilinear"
+          },
+          {
+            "__type": "Sandbox.ParticleSphereEmitter",
+            "__guid": "aa79498c-82a3-4823-9f26-a5eda7dac889",
+            "__enabled": true,
+            "Burst": 0,
+            "Delay": 0,
+            "DestroyOnEnd": false,
+            "Duration": 5,
+            "Loop": true,
+            "OnComponentDestroy": null,
+            "OnComponentDisabled": null,
+            "OnComponentEnabled": null,
+            "OnComponentFixedUpdate": null,
+            "OnComponentStart": null,
+            "OnComponentUpdate": null,
+            "OnEdge": false,
+            "Radius": 2,
+            "Rate": 100,
+            "RateOverDistance": 0,
+            "Velocity": 0
+          }
+        ],
+        "Children": []
+      }
+    ],
+    "__properties": {
+      "NetworkInterpolation": true,
+      "TimeScale": 1,
+      "WantsSystemScene": true,
+      "Metadata": {},
+      "NavMesh": {
+        "Enabled": false,
+        "IncludeStaticBodies": true,
+        "IncludeKeyframedBodies": true,
+        "EditorAutoUpdate": true,
+        "AgentHeight": 64,
+        "AgentRadius": 16,
+        "AgentStepSize": 18,
+        "AgentMaxSlope": 40,
+        "ExcludedBodies": "",
+        "IncludedBodies": ""
+      }
+    },
+    "__variables": []
+  },
+  "ResourceVersion": 2,
+  "ShowInMenu": false,
+  "MenuPath": null,
+  "MenuIcon": null,
+  "DontBreakAsTemplate": false,
+  "__references": [],
+  "__version": 2
+}

--- a/Assets/prefabs/weapons/physgun/physgun_beam.vmat
+++ b/Assets/prefabs/weapons/physgun/physgun_beam.vmat
@@ -1,0 +1,16 @@
+// THIS FILE IS AUTO-GENERATED
+
+Layer0
+{
+	shader "shaders/line.shader"
+
+	//---- Fog ----
+	g_bFogEnabled "1"
+
+	//---- Material ----
+	TextureAmbientOcclusion "materials/default/default_ao.tga"
+	TextureColor "textures/beams/lava.png"
+	TextureMetalness "materials/default/default_metal.tga"
+	TextureNormal "materials/default/default_normal.tga"
+	TextureRoughness "materials/default/default_rough.tga"
+}

--- a/Assets/prefabs/weapons/physgun/v_physgun.prefab
+++ b/Assets/prefabs/weapons/physgun/v_physgun.prefab
@@ -47,9 +47,9 @@
         "__version": 2,
         "Flags": 0,
         "Name": "viewmodel",
-        "Position": "0,0,0",
+        "Position": "1,-2.5,0",
         "Rotation": "0,0,0,1",
-        "Scale": "1,1,1",
+        "Scale": "0.550000012,1,1",
         "Tags": "",
         "Enabled": true,
         "NetworkMode": 2,
@@ -91,12 +91,12 @@
             },
             "PlaybackRate": 1,
             "RenderOptions": {
-              "GameLayer": true,
-              "OverlayLayer": false,
+              "GameLayer": false,
+              "OverlayLayer": true,
               "BloomLayer": false,
               "AfterUILayer": false
             },
-            "RenderType": "Off",
+            "RenderType": "On",
             "Sequence": {
               "Name": "idle",
               "Looping": true,
@@ -164,7 +164,7 @@
                   "BloomLayer": false,
                   "AfterUILayer": false
                 },
-                "RenderType": "On",
+                "RenderType": "Off",
                 "Sequence": {
                   "Name": null,
                   "Looping": true,
@@ -210,7 +210,7 @@
                     "MaterialGroup": null,
                     "MaterialOverride": null,
                     "Materials": null,
-                    "Model": "models/first_person/first_person_arms.vmdl",
+                    "Model": "models/first_person/v_first_person_arms_human.vmdl",
                     "Morphs": {},
                     "OnComponentDestroy": null,
                     "OnComponentDisabled": null,
@@ -230,11 +230,11 @@
                     "PlaybackRate": 1,
                     "RenderOptions": {
                       "GameLayer": false,
-                      "OverlayLayer": false,
+                      "OverlayLayer": true,
                       "BloomLayer": false,
                       "AfterUILayer": false
                     },
-                    "RenderType": "Off",
+                    "RenderType": "On",
                     "Sequence": {
                       "Name": "bindPose",
                       "Looping": true,
@@ -279,6 +279,7 @@
   "MenuIcon": null,
   "DontBreakAsTemplate": false,
   "__references": [
+    "facepunch.v_first_person_arms_human#205798",
     "katka.gravitygun#38114",
     "katka.hand_adapter_valvebiped_to_sbox#36579"
   ],

--- a/Assets/prefabs/weapons/physgun/v_physgun.prefab
+++ b/Assets/prefabs/weapons/physgun/v_physgun.prefab
@@ -1,13 +1,25 @@
 {
   "RootObject": {
     "__guid": "14b1b05e-52f7-4cca-88a6-23dfc1310933",
+    "__version": 2,
     "Flags": 0,
     "Name": "v_physgun",
+    "Position": "0,0,0",
+    "Rotation": "0,0,0,1",
+    "Scale": "1,1,1",
+    "Tags": "",
     "Enabled": true,
+    "NetworkMode": 2,
+    "NetworkFlags": 0,
+    "NetworkOrphaned": 0,
+    "NetworkTransmit": true,
+    "OwnerTransfer": 1,
     "Components": [
       {
         "__type": "ViewModel",
         "__guid": "366ed270-3f31-4896-9475-d90d8978c632",
+        "__enabled": true,
+        "Flags": 0,
         "BobCycleTime": 7,
         "BobDirection": "0,1,0.5",
         "EnableSwingAndBob": true,
@@ -32,20 +44,34 @@
     "Children": [
       {
         "__guid": "ac7e8998-e8dd-4904-8f7d-92ecf4400bd4",
+        "__version": 2,
         "Flags": 0,
         "Name": "viewmodel",
+        "Position": "0,0,0",
+        "Rotation": "0,0,0,1",
+        "Scale": "1,1,1",
+        "Tags": "",
         "Enabled": true,
+        "NetworkMode": 2,
+        "NetworkFlags": 0,
+        "NetworkOrphaned": 0,
+        "NetworkTransmit": true,
+        "OwnerTransfer": 1,
         "Components": [
           {
             "__type": "Sandbox.SkinnedModelRenderer",
             "__guid": "36bee89f-f4d8-49ac-9fcd-64bf29b29139",
+            "__enabled": true,
+            "Flags": 0,
             "AnimationGraph": null,
             "BodyGroups": 7,
             "BoneMergeTarget": null,
             "CreateAttachments": false,
             "CreateBoneObjects": false,
+            "LodOverride": null,
             "MaterialGroup": null,
             "MaterialOverride": null,
+            "Materials": null,
             "Model": "models/gravitygun/v_gravitygun.vmdl",
             "Morphs": {},
             "OnComponentDestroy": null,
@@ -63,6 +89,7 @@
               "vectors": {},
               "rotations": {}
             },
+            "PlaybackRate": 1,
             "RenderOptions": {
               "GameLayer": true,
               "OverlayLayer": false,
@@ -71,7 +98,9 @@
             },
             "RenderType": "Off",
             "Sequence": {
-              "Name": "idle"
+              "Name": "idle",
+              "Looping": true,
+              "Blending": false
             },
             "Tint": "1,1,1,1",
             "UseAnimGraph": true
@@ -80,14 +109,25 @@
         "Children": [
           {
             "__guid": "8758ef62-506f-4797-8448-f6fe6a3b92ba",
+            "__version": 2,
             "Flags": 0,
             "Name": "hand_adapter",
             "Position": "0,0,1",
+            "Rotation": "0,0,0,1",
+            "Scale": "1,1,1",
+            "Tags": "",
             "Enabled": true,
+            "NetworkMode": 2,
+            "NetworkFlags": 0,
+            "NetworkOrphaned": 0,
+            "NetworkTransmit": true,
+            "OwnerTransfer": 1,
             "Components": [
               {
                 "__type": "Sandbox.SkinnedModelRenderer",
                 "__guid": "a96da39d-4479-4ff8-b910-ea19ccb7da57",
+                "__enabled": true,
+                "Flags": 0,
                 "AnimationGraph": null,
                 "BodyGroups": 18446744073709551615,
                 "BoneMergeTarget": {
@@ -98,8 +138,10 @@
                 },
                 "CreateAttachments": false,
                 "CreateBoneObjects": false,
+                "LodOverride": null,
                 "MaterialGroup": null,
                 "MaterialOverride": null,
+                "Materials": null,
                 "Model": "models/hand_adapter_valvebiped_to_sbox/hand_adapter_valvebiped_to_sbox.vmdl",
                 "Morphs": {},
                 "OnComponentDestroy": null,
@@ -115,6 +157,7 @@
                   "vectors": {},
                   "rotations": {}
                 },
+                "PlaybackRate": 1,
                 "RenderOptions": {
                   "GameLayer": false,
                   "OverlayLayer": false,
@@ -123,7 +166,9 @@
                 },
                 "RenderType": "On",
                 "Sequence": {
-                  "Name": null
+                  "Name": null,
+                  "Looping": true,
+                  "Blending": false
                 },
                 "Tint": "1,1,1,1",
                 "UseAnimGraph": false
@@ -132,13 +177,25 @@
             "Children": [
               {
                 "__guid": "b2f02866-443c-4bb6-9930-46031b3d075f",
+                "__version": 2,
                 "Flags": 0,
                 "Name": "hands",
+                "Position": "0,0,0",
+                "Rotation": "0,0,0,1",
+                "Scale": "1,1,1",
+                "Tags": "",
                 "Enabled": true,
+                "NetworkMode": 2,
+                "NetworkFlags": 0,
+                "NetworkOrphaned": 0,
+                "NetworkTransmit": true,
+                "OwnerTransfer": 1,
                 "Components": [
                   {
                     "__type": "Sandbox.SkinnedModelRenderer",
                     "__guid": "f68720f1-a3a4-4b84-88d0-91181f385283",
+                    "__enabled": true,
+                    "Flags": 0,
                     "AnimationGraph": null,
                     "BodyGroups": 21,
                     "BoneMergeTarget": {
@@ -149,8 +206,10 @@
                     },
                     "CreateAttachments": false,
                     "CreateBoneObjects": false,
+                    "LodOverride": null,
                     "MaterialGroup": null,
                     "MaterialOverride": null,
+                    "Materials": null,
                     "Model": "models/first_person/first_person_arms.vmdl",
                     "Morphs": {},
                     "OnComponentDestroy": null,
@@ -168,6 +227,7 @@
                       "vectors": {},
                       "rotations": {}
                     },
+                    "PlaybackRate": 1,
                     "RenderOptions": {
                       "GameLayer": false,
                       "OverlayLayer": false,
@@ -176,51 +236,51 @@
                     },
                     "RenderType": "Off",
                     "Sequence": {
-                      "Name": "bindPose"
+                      "Name": "bindPose",
+                      "Looping": true,
+                      "Blending": false
                     },
                     "Tint": "1,1,1,1",
                     "UseAnimGraph": false
                   }
-                ]
+                ],
+                "Children": []
               }
             ]
           }
         ]
       }
     ],
-    "__variables": [],
     "__properties": {
-      "FixedUpdateFrequency": 50,
-      "MaxFixedUpdates": 5,
-      "NetworkFrequency": 30,
       "NetworkInterpolation": true,
-      "PhysicsSubSteps": 1,
-      "ThreadedAnimation": true,
       "TimeScale": 1,
-      "UseFixedUpdate": true,
+      "WantsSystemScene": true,
       "Metadata": {},
       "NavMesh": {
         "Enabled": false,
         "IncludeStaticBodies": true,
         "IncludeKeyframedBodies": true,
-        "EditorAutoUpdate": true,
+        "EditorAutoUpdate": false,
         "AgentHeight": 64,
         "AgentRadius": 16,
         "AgentStepSize": 18,
         "AgentMaxSlope": 40,
         "ExcludedBodies": "",
-        "IncludedBodies": ""
+        "IncludedBodies": "",
+        "DeferGeneration": false,
+        "CustomBounds": false
       }
-    }
+    },
+    "__variables": []
   },
+  "ResourceVersion": 2,
   "ShowInMenu": false,
   "MenuPath": null,
   "MenuIcon": null,
   "DontBreakAsTemplate": false,
-  "ResourceVersion": 1,
   "__references": [
     "katka.gravitygun#38114",
     "katka.hand_adapter_valvebiped_to_sbox#36579"
   ],
-  "__version": 1
+  "__version": 2
 }

--- a/Assets/prefabs/weapons/physgun/w_physgun.prefab
+++ b/Assets/prefabs/weapons/physgun/w_physgun.prefab
@@ -1,59 +1,59 @@
 {
   "RootObject": {
     "__guid": "543861fb-2906-4175-8265-02b4e8a8e1d7",
+    "__version": 2,
     "Flags": 0,
     "Name": "w_physgun",
+    "Position": "0,0,0",
+    "Rotation": "0,0,0,1",
+    "Scale": "1,1,1",
     "Tags": "item,weapon",
     "Enabled": true,
-    "Components": [
-      {
-        "__type": "PhysGun",
-        "__guid": "fed3414c-e272-4756-9db5-b1bffab412d4",
-        "AngularDampingRatio": 1,
-        "AngularFrequency": 20,
-        "BoneOffset": {
-          "UniformScale": 1,
-          "IsValid": true,
-          "ForwardRay": {
-            "Forward": "1,0,0"
-          },
-          "Scale": "1,1,1",
-          "Rotation": "0,0,0,1"
-        },
-        "Handedness": "Both",
-        "HoldType": "Pistol",
-        "LinearDampingRatio": 1,
-        "LinearFrequency": 20,
-        "MaxTargetDistance": 10000,
-        "MinTargetDistance": 0,
-        "ParentBone": "hold_r",
-        "PrimaryRate": 5,
-        "ReloadTime": 3,
-        "RotateSnapAt": 45,
-        "RotateSpeed": 0.125,
-        "SecondaryRate": 15,
-        "TargetDistanceSpeed": 25,
-        "ViewModelPrefab": {
-          "_type": "gameobject",
-          "prefab": "prefabs/weapons/physgun/v_physgun.prefab"
-        }
-      }
-    ],
+    "NetworkMode": 2,
+    "NetworkFlags": 0,
+    "NetworkOrphaned": 0,
+    "NetworkTransmit": true,
+    "OwnerTransfer": 1,
+    "Components": [],
     "Children": [
       {
         "__guid": "11af0201-9f7d-4e7f-acd4-6e017d7f0f84",
+        "__version": 2,
         "Flags": 0,
         "Name": "Model",
+        "Position": "0,0,0",
+        "Rotation": "0,0,0,1",
+        "Scale": "1,1,1",
+        "Tags": "",
         "Enabled": true,
+        "NetworkMode": 2,
+        "NetworkFlags": 0,
+        "NetworkOrphaned": 0,
+        "NetworkTransmit": true,
+        "OwnerTransfer": 1,
         "Components": [
           {
             "__type": "Sandbox.SkinnedModelRenderer",
             "__guid": "4601d044-1e9a-4769-b7bf-74b1dff621ab",
+            "__enabled": true,
+            "Flags": 0,
+            "AnimationGraph": null,
             "BodyGroups": 18446744073709551615,
+            "BoneMergeTarget": null,
             "CreateAttachments": false,
             "CreateBoneObjects": false,
+            "LodOverride": null,
+            "MaterialGroup": null,
+            "MaterialOverride": null,
+            "Materials": null,
             "Model": "weapons/rust_pistol/rust_pistol.vmdl",
             "Morphs": {},
+            "OnComponentDestroy": null,
+            "OnComponentDisabled": null,
+            "OnComponentEnabled": null,
+            "OnComponentFixedUpdate": null,
+            "OnComponentStart": null,
+            "OnComponentUpdate": null,
             "Parameters": {
               "bools": {},
               "ints": {},
@@ -61,6 +61,7 @@
               "vectors": {},
               "rotations": {}
             },
+            "PlaybackRate": 1,
             "RenderOptions": {
               "GameLayer": true,
               "OverlayLayer": false,
@@ -68,51 +69,65 @@
               "AfterUILayer": false
             },
             "RenderType": "On",
+            "Sequence": {
+              "Name": null,
+              "Looping": true,
+              "Blending": false
+            },
             "Tint": "1,1,1,1",
             "UseAnimGraph": true
           }
-        ]
+        ],
+        "Children": []
       },
       {
         "__guid": "cf3daeb0-93c9-479f-adf4-1ae4d7e43fe9",
+        "__version": 2,
         "Flags": 0,
         "Name": "Muzzle",
-        "Position": "11,0.05042475,4.575",
-        "Enabled": true
+        "Position": "11,0.0504247509,4.57499981",
+        "Rotation": "0,0,0,1",
+        "Scale": "1,1,1",
+        "Tags": "",
+        "Enabled": true,
+        "NetworkMode": 2,
+        "NetworkFlags": 0,
+        "NetworkOrphaned": 0,
+        "NetworkTransmit": true,
+        "OwnerTransfer": 1,
+        "Components": [],
+        "Children": []
       }
     ],
-    "__variables": [],
     "__properties": {
-      "FixedUpdateFrequency": 50,
-      "MaxFixedUpdates": 5,
-      "NetworkFrequency": 30,
       "NetworkInterpolation": true,
-      "PhysicsSubSteps": 1,
-      "ThreadedAnimation": true,
       "TimeScale": 1,
-      "UseFixedUpdate": true,
+      "WantsSystemScene": true,
       "Metadata": {},
       "NavMesh": {
         "Enabled": false,
         "IncludeStaticBodies": true,
         "IncludeKeyframedBodies": true,
-        "EditorAutoUpdate": true,
+        "EditorAutoUpdate": false,
         "AgentHeight": 64,
         "AgentRadius": 16,
         "AgentStepSize": 18,
         "AgentMaxSlope": 40,
         "ExcludedBodies": "",
-        "IncludedBodies": ""
+        "IncludedBodies": "",
+        "DeferGeneration": false,
+        "CustomBounds": false
       }
-    }
+    },
+    "__variables": []
   },
+  "ResourceVersion": 2,
   "ShowInMenu": false,
   "MenuPath": null,
   "MenuIcon": null,
   "DontBreakAsTemplate": false,
-  "ResourceVersion": 1,
   "__references": [
     "rust.rust_pistol#43964"
   ],
-  "__version": 1
+  "__version": 2
 }

--- a/Assets/prefabs/weapons/physgun/weapon_physgun.prefab
+++ b/Assets/prefabs/weapons/physgun/weapon_physgun.prefab
@@ -1,0 +1,304 @@
+{
+  "RootObject": {
+    "__guid": "543861fb-2906-4175-8265-02b4e8a8e1d7",
+    "__version": 2,
+    "Flags": 0,
+    "Name": "weapon_physgun",
+    "Position": "0,0,0",
+    "Rotation": "0,0,0,1",
+    "Scale": "1,1,1",
+    "Tags": "item,weapon",
+    "Enabled": true,
+    "NetworkMode": 2,
+    "NetworkFlags": 0,
+    "NetworkOrphaned": 0,
+    "NetworkTransmit": true,
+    "OwnerTransfer": 1,
+    "Components": [
+      {
+        "__type": "PhysGun",
+        "__guid": "fed3414c-e272-4756-9db5-b1bffab412d4",
+        "__enabled": true,
+        "Flags": 0,
+        "AngularDampingRatio": 1,
+        "AngularFrequency": 20,
+        "BeamRenderer": {
+          "_type": "component",
+          "component_id": "df9759c6-941a-4f38-87ed-2649d26b77fc",
+          "go": "35c2ba87-5728-440c-ad84-b1e7e96d8d27",
+          "component_type": "LineRenderer"
+        },
+        "BoneOffset": {
+          "Position": "0,0,0",
+          "Scale": "1,1,1",
+          "Rotation": "0,0,0,1"
+        },
+        "EndPointEffectPrefab": {
+          "_type": "gameobject",
+          "prefab": "prefabs/weapons/physgun/effects/beam-end.prefab"
+        },
+        "FreezeEffectPrefab": {
+          "_type": "gameobject",
+          "prefab": "prefabs/weapons/physgun/effects/freeze.prefab"
+        },
+        "GrabEffectPrefab": {
+          "_type": "gameobject",
+          "prefab": "prefabs/weapons/physgun/effects/grab.prefab"
+        },
+        "Handedness": "Both",
+        "HoldType": "Pistol",
+        "LinearDampingRatio": 1,
+        "LinearFrequency": 20,
+        "MaxTargetDistance": 10000,
+        "MinTargetDistance": 0,
+        "OnComponentDestroy": null,
+        "OnComponentDisabled": null,
+        "OnComponentEnabled": null,
+        "OnComponentFixedUpdate": null,
+        "OnComponentStart": null,
+        "OnComponentUpdate": null,
+        "ParentBone": "hold_r",
+        "PrimaryRate": 5,
+        "ReloadTime": 3,
+        "RotateSnapAt": 45,
+        "RotateSpeed": 0.125,
+        "SecondaryRate": 15,
+        "TargetDistanceSpeed": 25,
+        "UnFreezeEffectPrefab": {
+          "_type": "gameobject",
+          "prefab": "prefabs/weapons/physgun/effects/unfreeze.prefab"
+        },
+        "ViewModelPrefab": {
+          "_type": "gameobject",
+          "prefab": "prefabs/weapons/physgun/v_physgun.prefab"
+        },
+        "WorldModelPrefab": {
+          "_type": "gameobject",
+          "prefab": "prefabs/weapons/physgun/w_physgun.prefab"
+        }
+      }
+    ],
+    "Children": [
+      {
+        "__guid": "11af0201-9f7d-4e7f-acd4-6e017d7f0f84",
+        "__version": 2,
+        "Flags": 0,
+        "Name": "Model",
+        "Position": "0,0,0",
+        "Rotation": "0,0,0,1",
+        "Scale": "1,1,1",
+        "Tags": "",
+        "Enabled": false,
+        "NetworkMode": 2,
+        "NetworkFlags": 0,
+        "NetworkOrphaned": 0,
+        "NetworkTransmit": true,
+        "OwnerTransfer": 1,
+        "Components": [
+          {
+            "__type": "Sandbox.SkinnedModelRenderer",
+            "__guid": "4601d044-1e9a-4769-b7bf-74b1dff621ab",
+            "__enabled": true,
+            "Flags": 0,
+            "AnimationGraph": null,
+            "BodyGroups": 18446744073709551615,
+            "BoneMergeTarget": null,
+            "CreateAttachments": false,
+            "CreateBoneObjects": false,
+            "LodOverride": null,
+            "MaterialGroup": null,
+            "MaterialOverride": null,
+            "Materials": null,
+            "Model": "weapons/rust_pistol/rust_pistol.vmdl",
+            "Morphs": {},
+            "OnComponentDestroy": null,
+            "OnComponentDisabled": null,
+            "OnComponentEnabled": null,
+            "OnComponentFixedUpdate": null,
+            "OnComponentStart": null,
+            "OnComponentUpdate": null,
+            "Parameters": {
+              "bools": {},
+              "ints": {},
+              "floats": {},
+              "vectors": {},
+              "rotations": {}
+            },
+            "PlaybackRate": 1,
+            "RenderOptions": {
+              "GameLayer": true,
+              "OverlayLayer": false,
+              "BloomLayer": false,
+              "AfterUILayer": false
+            },
+            "RenderType": "On",
+            "Sequence": {
+              "Name": null,
+              "Looping": true,
+              "Blending": false
+            },
+            "Tint": "1,1,1,1",
+            "UseAnimGraph": true
+          }
+        ],
+        "Children": []
+      },
+      {
+        "__guid": "cf3daeb0-93c9-479f-adf4-1ae4d7e43fe9",
+        "__version": 2,
+        "Flags": 0,
+        "Name": "Muzzle",
+        "Position": "11,0.0504247509,4.57499981",
+        "Rotation": "0,0,0,1",
+        "Scale": "1,1,1",
+        "Tags": "",
+        "Enabled": true,
+        "NetworkMode": 2,
+        "NetworkFlags": 0,
+        "NetworkOrphaned": 0,
+        "NetworkTransmit": true,
+        "OwnerTransfer": 1,
+        "Components": [],
+        "Children": []
+      },
+      {
+        "__guid": "35c2ba87-5728-440c-ad84-b1e7e96d8d27",
+        "__version": 2,
+        "Flags": 0,
+        "Name": "Beam",
+        "Position": "0,0,0",
+        "Rotation": "0,0,0,1",
+        "Scale": "1.5,1.5,1.5",
+        "Tags": "",
+        "Enabled": false,
+        "NetworkMode": 2,
+        "NetworkFlags": 0,
+        "NetworkOrphaned": 0,
+        "NetworkTransmit": true,
+        "OwnerTransfer": 1,
+        "Components": [
+          {
+            "__type": "Sandbox.LineRenderer",
+            "__guid": "df9759c6-941a-4f38-87ed-2649d26b77fc",
+            "__enabled": true,
+            "Flags": 0,
+            "Additive": true,
+            "AutoCalculateNormals": true,
+            "CastShadows": false,
+            "Color": {
+              "blend": "Linear",
+              "color": [
+                {
+                  "t": 0.51890755,
+                  "c": "1.74419,2.7907,3,1"
+                }
+              ],
+              "alpha": []
+            },
+            "CylinderSegments": 12,
+            "DepthFeather": 4,
+            "EndCap": "None",
+            "Face": "Camera",
+            "FogStrength": 1,
+            "Lighting": false,
+            "OnComponentDestroy": null,
+            "OnComponentDisabled": null,
+            "OnComponentEnabled": null,
+            "OnComponentFixedUpdate": null,
+            "OnComponentStart": null,
+            "OnComponentUpdate": null,
+            "Opaque": false,
+            "Points": [],
+            "RenderOptions": {
+              "GameLayer": true,
+              "OverlayLayer": false,
+              "BloomLayer": false,
+              "AfterUILayer": false
+            },
+            "SplineBias": 0,
+            "SplineContinuity": 0,
+            "SplineInterpolation": 8,
+            "SplineTension": 0,
+            "StartCap": "None",
+            "Texturing": {
+              "Texture": null,
+              "Material": "prefabs/weapons/physgun/physgun_beam.vmat",
+              "WorldSpace": true,
+              "UnitsPerTexture": 512,
+              "Scale": 1,
+              "Offset": 0,
+              "Scroll": 1,
+              "FilterMode": "Anisotropic",
+              "TextureAddressMode": "Wrap",
+              "Clamp": false
+            },
+            "UseVectorPoints": true,
+            "VectorPoints": [
+              "0,0,0",
+              "163.400208,0,0",
+              "307.799988,126.599998,0"
+            ],
+            "Width": {
+              "rangey": "0.167400002,5",
+              "frames": [
+                {
+                  "x": 0,
+                  "y": 0.676678,
+                  "in": -0.9629625,
+                  "out": 0.9629625,
+                  "mode": "Mirrored"
+                },
+                {
+                  "x": 0.46773395,
+                  "y": 1,
+                  "in": 0,
+                  "out": 0,
+                  "mode": "Mirrored"
+                },
+                {
+                  "x": 1,
+                  "y": 0,
+                  "in": 5.7647076,
+                  "out": -5.7647076,
+                  "mode": "Mirrored"
+                }
+              ]
+            },
+            "Wireframe": false
+          }
+        ],
+        "Children": []
+      }
+    ],
+    "__properties": {
+      "NetworkInterpolation": true,
+      "TimeScale": 1,
+      "WantsSystemScene": true,
+      "Metadata": {},
+      "NavMesh": {
+        "Enabled": false,
+        "IncludeStaticBodies": true,
+        "IncludeKeyframedBodies": true,
+        "EditorAutoUpdate": false,
+        "AgentHeight": 64,
+        "AgentRadius": 16,
+        "AgentStepSize": 18,
+        "AgentMaxSlope": 40,
+        "ExcludedBodies": "",
+        "IncludedBodies": "",
+        "DeferGeneration": false,
+        "CustomBounds": false
+      }
+    },
+    "__variables": []
+  },
+  "ResourceVersion": 2,
+  "ShowInMenu": false,
+  "MenuPath": null,
+  "MenuIcon": null,
+  "DontBreakAsTemplate": false,
+  "__references": [
+    "rust.rust_pistol#43964"
+  ],
+  "__version": 2
+}

--- a/Assets/prefabs/weapons/physgun/weapon_physgun.prefab
+++ b/Assets/prefabs/weapons/physgun/weapon_physgun.prefab
@@ -33,6 +33,8 @@
           "Scale": "1,1,1",
           "Rotation": "0,0,0,1"
         },
+        "ColorCrystalGlass": "0.11236,0.32988,0.45581,1",
+        "ColorCrystalInside": "0.63922,0.8,0.8902,1",
         "EndPointEffectPrefab": {
           "_type": "gameobject",
           "prefab": "prefabs/weapons/physgun/effects/beam-end.prefab"

--- a/Code/Components/Base/BaseWeapon.cs
+++ b/Code/Components/Base/BaseWeapon.cs
@@ -8,6 +8,7 @@ using Sandbox.Citizen;
 public partial class BaseWeapon : Component, SandboxPlus.PlayerController.IEvents
 {
 	[Property] public GameObject ViewModelPrefab { get; set; }
+	[Property] public GameObject WorldModelPrefab { get; set; }
 	[Property] public string ParentBone { get; set; } = "hold_r";
 	[Property] public Transform BoneOffset { get; set; } = new Transform( 0 );
 	[Property] public CitizenAnimationHelper.HoldTypes HoldType { get; set; } = CitizenAnimationHelper.HoldTypes.HoldItem;
@@ -23,7 +24,8 @@ public partial class BaseWeapon : Component, SandboxPlus.PlayerController.IEvent
 	[Sync] public RealTimeSince TimeSinceSecondaryAttack { get; set; }
 
 	public ViewModel ViewModel => Scene?.Camera?.Components.GetInDescendantsOrSelf<ViewModel>( true );
-	public SkinnedModelRenderer WorldModel => GameObject?.GetComponentInChildren<SkinnedModelRenderer>( true );
+	public GameObject WorldModelObject = null;
+	public SkinnedModelRenderer WorldModel => WorldModelObject?.GetComponentInChildren<SkinnedModelRenderer>( true );
 	public SkinnedModelRenderer LocalWorldModel => !Owner.IsValid() || !Owner.Controller.IsValid() || Owner.Controller.ThirdPerson || IsProxy ? WorldModel : ViewModel?.Renderer;
 	public Player Owner => GameObject?.Root?.GetComponent<Player>();
 
@@ -53,8 +55,8 @@ public partial class BaseWeapon : Component, SandboxPlus.PlayerController.IEvent
 		var obj = Owner?.Controller?.Renderer?.GetBoneObject( ParentBone );
 		if ( obj is not null )
 		{
-			GameObject.Parent = obj;
-			GameObject.LocalTransform = BoneOffset.WithScale( 1 );
+			WorldModelObject?.Parent = obj;
+			WorldModelObject?.LocalTransform = BoneOffset.WithScale( 1 );
 		}
 	}
 
@@ -66,14 +68,43 @@ public partial class BaseWeapon : Component, SandboxPlus.PlayerController.IEvent
 
 		if ( IsProxy ) return;
 
-		var go = ViewModelPrefab?.Clone( new CloneConfig()
+		var vm = ViewModelPrefab?.Clone( new CloneConfig()
 		{
 			StartEnabled = true,
 			Parent = Scene.Camera.GameObject,
 			Transform = Scene.Camera.WorldTransform
 		} );
 
-		go.NetworkMode = NetworkMode.Never;
+		if (vm.IsValid())
+		{
+			vm.Flags |= GameObjectFlags.NotSaved | GameObjectFlags.NotNetworked;
+			vm.NetworkMode = NetworkMode.Never;
+			vm.Tags.Add( "firstperson", "viewmodel" );
+		}
+
+		var wm = WorldModelPrefab?.Clone(new CloneConfig()
+		{
+			StartEnabled = true,
+			Parent = GameObject,
+			Transform = WorldTransform
+		});
+
+		if (wm.IsValid())
+		{
+			wm.Flags |= GameObjectFlags.NotSaved | GameObjectFlags.NotNetworked;
+			WorldModelObject = wm;
+		}
+		else
+		{
+			WorldModelObject = GameObject;
+		}
+		
+		var obj = Owner?.Controller?.Renderer?.GetBoneObject( ParentBone );
+		if ( obj is not null )
+		{
+			WorldModelObject?.Parent = obj;
+			WorldModelObject?.LocalTransform = BoneOffset.WithScale( 1 );
+		}
 	}
 
 	[Rpc.Broadcast]

--- a/Code/Components/Base/BaseWeapon.cs
+++ b/Code/Components/Base/BaseWeapon.cs
@@ -24,6 +24,7 @@ public partial class BaseWeapon : Component, SandboxPlus.PlayerController.IEvent
 	[Sync] public RealTimeSince TimeSinceSecondaryAttack { get; set; }
 
 	public ViewModel ViewModel => Scene?.Camera?.Components.GetInDescendantsOrSelf<ViewModel>( true );
+	public GameObject ViewModelObject = null;
 	public GameObject WorldModelObject = null;
 	public SkinnedModelRenderer WorldModel => WorldModelObject?.GetComponentInChildren<SkinnedModelRenderer>( true );
 	public SkinnedModelRenderer LocalWorldModel => !Owner.IsValid() || !Owner.Controller.IsValid() || Owner.Controller.ThirdPerson || IsProxy ? WorldModel : ViewModel?.Renderer;
@@ -80,6 +81,7 @@ public partial class BaseWeapon : Component, SandboxPlus.PlayerController.IEvent
 			vm.Flags |= GameObjectFlags.NotSaved | GameObjectFlags.NotNetworked;
 			vm.NetworkMode = NetworkMode.Never;
 			vm.Tags.Add( "firstperson", "viewmodel" );
+			ViewModelObject = vm;
 		}
 
 		var wm = WorldModelPrefab?.Clone(new CloneConfig()

--- a/Code/Components/Player/PlayerInventory.cs
+++ b/Code/Components/Player/PlayerInventory.cs
@@ -10,7 +10,7 @@ public sealed class PlayerInventory : Component, IPlayerEvent
 
 	public void GiveDefaultWeapons()
 	{
-		Pickup( "prefabs/weapons/physgun/w_physgun.prefab" );
+		Pickup( "prefabs/weapons/physgun/weapon_physgun.prefab" );
 		Pickup( "prefabs/weapons/gravgun/w_gravgun.prefab" );
 		Pickup( "prefabs/weapons/toolgun/w_toolgun-gmod.prefab" );
 		Pickup( "prefabs/weapons/pistol/w_pistol.prefab" );
@@ -45,7 +45,7 @@ public sealed class PlayerInventory : Component, IPlayerEvent
 
 	private void Pickup( string prefabName )
 	{
-		var prefab = GameObject.Clone( prefabName, global::Transform.Zero, Owner.Body, false );
+		var prefab = GameObject.Clone( prefabName, global::Transform.Zero, Owner.GameObject, false );
 		prefab.NetworkSpawn( false, Network.Owner );
 
 		var weapon = prefab.Components.Get<BaseWeapon>( true );

--- a/Code/Components/Weapons/PhysGun.Effects.cs
+++ b/Code/Components/Weapons/PhysGun.Effects.cs
@@ -1,23 +1,40 @@
-﻿public partial class PhysGun
+﻿using Sandbox.Rendering;
+using Sandbox.Utility;
+
+public partial class PhysGun
 {
-	LegacyParticleSystem beam;
-	LegacyParticleSystem endNoHit;
+	[Property] public LineRenderer BeamRenderer { get; set; }
+	[Property] public GameObject EndPointEffectPrefab { get; set; }
+	[Property] public GameObject FreezeEffectPrefab { get; set; }
+	[Property] public GameObject UnFreezeEffectPrefab { get; set; }
+	[Property] public GameObject GrabEffectPrefab { get; set; }
+	
+	GameObject _endPointEffect;
+	GameObject _grabEffect;
 
 	GameObject lastGrabbedObject;
+	
+	Vector3.SpringDamped middleSpring = new Vector3.SpringDamped( 0, 0 );
+	private float _prevBeamDistance = 0;
 
 	[Rpc.Broadcast]
 	protected virtual void KillEffects()
 	{
-		if ( beam.IsValid() )
+		if ( _endPointEffect.IsValid() )
 		{
-			beam?.GameObject?.Destroy();
-			beam = null;
+			_endPointEffect?.Destroy();
+			_endPointEffect = null;
 		}
 
-		if ( endNoHit.IsValid() )
+		if ( _grabEffect.IsValid() )
 		{
-			endNoHit?.GameObject?.Destroy();
-			endNoHit = null;
+			_grabEffect?.Destroy();
+			_grabEffect = null;
+		}
+
+		if (BeamRenderer.IsValid())
+		{
+			BeamRenderer.GameObject.Enabled = false;
 		}
 
 		DisableHighlights( lastGrabbedObject );
@@ -62,23 +79,20 @@
 		}
 
 		var startPos = Owner.EyeTransform.Position;
+		var endPos = startPos + Owner.EyeTransform.Forward * MaxTargetDistance;
 		var dir = Owner.EyeTransform.Forward;
 
-		var tr = Scene.Trace.Ray( startPos, startPos + dir * MaxTargetDistance )
+		var tr = Scene.Trace.Ray( startPos, endPos )
 			.UseHitboxes()
 			.IgnoreGameObject( Owner.GameObject )
 			.WithAllTags( "solid" )
 			.WithoutTags( "player" )
 			.Run();
 
-		// LegacyParticleSystem is fully broken now, todo replace
-		// beam ??= CreateBeam( tr.EndPosition );
-
-		if ( beam.IsValid() )
-		{
-			beam.WorldPosition = Attachment( "muzzle" ).Position + dir * 10f;
-			beam.WorldRotation = Attachment( "muzzle" ).Rotation;
-		}
+		var muzzleAttachment = Attachment("muzzle");
+		var rotation = muzzleAttachment.Rotation;
+		startPos = muzzleAttachment.Position + dir * 10f;
+		endPos = tr.EndPosition;
 
 		if ( GrabbedObject.IsValid() && !GrabbedObject.Tags.Contains( "world" ) && HeldBody.IsValid() )
 		{
@@ -89,7 +103,7 @@
 				var physBody = physGroup.GetBody( GrabbedBone );
 				if ( physBody != null )
 				{
-					beam?.SceneObject.SetControlPoint( 1, physBody.Transform.PointToWorld( GrabbedPos ) );
+					endPos = physBody.Transform.PointToWorld(GrabbedPos);
 				}
 			}
 			else
@@ -97,13 +111,8 @@
 				if ( !HeldBody.IsValid() )
 					return;
 
-				beam?.SceneObject.SetControlPoint( 1, HeldBody.Transform.PointToWorld( GrabbedPos ) );
+				endPos = HeldBody.Transform.PointToWorld(GrabbedPos);
 			}
-
-			lastBeamPos = HeldBody.Position + HeldBody.Rotation * GrabbedPos;
-
-			endNoHit?.GameObject.Destroy();
-			endNoHit = null;
 
 			if ( GrabbedObject.GetComponent<ModelRenderer>().IsValid() )
 			{
@@ -126,27 +135,110 @@
 		}
 		else
 		{
-			lastBeamPos = tr.EndPosition;
-
-			Vector3.Lerp( lastBeamPos, tr.EndPosition, Time.Delta * 10 );
-
-			if ( beam?.IsValid() == true )
-				beam?.SceneObject.SetControlPoint( 1, lastBeamPos );
-
-			// LegacyParticleSystem is fully broken now, todo replace
-			// endNoHit ??= Particles.MakeParticleSystem( "particles/physgun_end_nohit.vpcf", new Transform( lastBeamPos ), 0 );
-			// endNoHit.SceneObject.SetControlPoint( 0, lastBeamPos );
-			// endNoHit.WorldPosition = lastBeamPos;
+			endPos = tr.EndPosition;
 		}
-	}
+		
+		var endTx = new Transform(endPos, rotation);
+		
+		if ( grabbed )
+		{
+			if ( _endPointEffect != null )
+			{
+				ITemporaryEffect.DisableLoopingEffects( _endPointEffect );
+				_endPointEffect = null;
+			}
 
-	private LegacyParticleSystem CreateBeam( Vector3 endPos ) =>
-		Particles.MakeParticleSystem( "particles/physgun_beam.vpcf", new Transform( endPos ), 0 );
+
+			if ( !_grabEffect.IsValid() )
+			{
+				_grabEffect = GrabEffectPrefab.Clone( endTx );
+			}
+
+			if ( _grabEffect.IsValid() )
+			{
+				_grabEffect.WorldTransform = endTx;
+			}
+
+		}
+		else
+		{
+			if ( _grabEffect != null )
+			{
+				_grabEffect.Destroy();
+				_grabEffect = null;
+			}
+
+			if ( !_endPointEffect.IsValid() )
+			{
+				_endPointEffect = EndPointEffectPrefab.Clone( endTx );
+			}
+
+			if ( _endPointEffect.IsValid() )
+			{
+				_endPointEffect.WorldTransform = endTx;
+			}
+		}
+		
+		bool justEnabled = !BeamRenderer.GameObject.Enabled;
+		
+		if ( BeamRenderer.VectorPoints == null || BeamRenderer.VectorPoints.Count != 4 )
+			BeamRenderer.VectorPoints = new List<Vector3>( [0, 0, 0, 0] );
+		
+		var distance = startPos.Distance( endPos );
+		var targetMiddle = startPos + rotation.Forward * distance * 0.33f;
+		targetMiddle += Noise.FbmVector(2, Time.Now * 400f, Time.Now * 100f);
+		
+		if ( !justEnabled )
+		{
+			// If the beam halved or more in a single frame, snap the spring to the new position to avoid shakiness
+			if ( _prevBeamDistance > 1f && distance / _prevBeamDistance < 0.5f )
+			{
+				middleSpring = new Vector3.SpringDamped( targetMiddle, targetMiddle, 4, 0.2f );
+			}
+
+			// Ensure the middle point is never behind the first one
+			var alongFwd = Vector3.Dot( middleSpring.Current - startPos, rotation.Forward );
+			if ( alongFwd < 0 )
+			{
+				var clamped = middleSpring.Current - rotation.Forward * alongFwd;
+				middleSpring = new Vector3.SpringDamped( clamped, targetMiddle, 4, 0.2f );
+			}
+		}
+
+		lastBeamPos = endPos;
+		BeamRenderer.VectorPoints[0] = startPos;
+		BeamRenderer.VectorPoints[1] = middleSpring.Current;
+		middleSpring.Target = targetMiddle;
+		middleSpring.Update( Time.Delta );
+		BeamRenderer.VectorPoints[2] = Vector3.Lerp(endPos + rotation.Backward * 10, BeamRenderer.VectorPoints[1], 0.3f + MathF.Sin(Time.Now * 10f) * 0.2f);
+		BeamRenderer.VectorPoints[3] = endPos;
+		
+		if ( justEnabled )
+		{
+			BeamRenderer.GameObject.Enabled = true;
+			_prevBeamDistance = distance;
+			BeamRenderer.VectorPoints[1] = targetMiddle;
+			middleSpring = new Vector3.SpringDamped( targetMiddle, targetMiddle, 4, 0.2f );
+		}
+
+	}
 
 	private void FreezeEffects()
 	{
-		// LegacyParticleSystem is fully broken now, todo replace
-		// return Particles.MakeParticleSystem( "particles/physgun_freeze.vpcf", new Transform( lastBeamPos ), 4 );
+		var effect = FreezeEffectPrefab.Clone( HeldBody.GameObject.WorldTransform );
+		foreach ( var emitter in effect.GetComponentsInChildren<ParticleModelEmitter>() )
+		{
+			emitter.Target = HeldBody.GameObject;
+		}
+	}
+
+	private void UnFreezeEffects()
+	{
+		var effect = UnFreezeEffectPrefab.Clone( HeldBody.GameObject.WorldTransform );
+		foreach ( var emitter in effect.GetComponentsInChildren<ParticleModelEmitter>() )
+		{
+			emitter.Target = HeldBody.GameObject;
+		}
 	}
 
 	protected override void OnDestroy()

--- a/Code/Components/Weapons/PhysGun.Effects.cs
+++ b/Code/Components/Weapons/PhysGun.Effects.cs
@@ -9,6 +9,15 @@ public partial class PhysGun
 	[Property] public GameObject UnFreezeEffectPrefab { get; set; }
 	[Property] public GameObject GrabEffectPrefab { get; set; }
 	
+	[Property]
+	public Color ColorCrystalGlass { get; set; } = Color.White;
+
+	[Property]
+	public Color ColorCrystalInside { get; set; } = Color.White;
+
+	private Material _matCrystal = null;
+	private Material _matCrystalInside = null;
+	
 	GameObject _endPointEffect;
 	GameObject _grabEffect;
 
@@ -63,16 +72,53 @@ public partial class PhysGun
 		}
 	}
 
+	private void CleanupMaterials()
+	{
+		_matCrystal = null;
+		_matCrystalInside = null;
+	}
+
+	private float _innerColorStrength = 1f;
+	private void UpdateMaterials()
+	{
+		var viewmodelRenderer = ViewModelObject?.GetComponentInChildren<ModelRenderer>();
+		if (viewmodelRenderer is null)
+			return;
+		
+		if (_matCrystal is null)
+		{
+			_matCrystal = viewmodelRenderer.Materials.GetOriginal(3).CreateCopy();
+			viewmodelRenderer.Materials.SetOverride( 3, _matCrystal );
+			Log.Info( "PhysGun: Created crystal material" );
+		}
+
+		if (_matCrystalInside is null)
+		{
+			_matCrystalInside = viewmodelRenderer.Materials.GetOriginal(4).CreateCopy();
+			viewmodelRenderer.Materials.SetOverride( 4, _matCrystalInside );
+			Log.Info( "PhysGun: Created crystal inside material" );
+		}
+
+		_matCrystal?.Set( "g_flTintColor", ColorCrystalGlass );
+
+		var strengthMult = Beaming ? 3f : 1f;
+		strengthMult *= MathF.Sin( Time.Now * (Beaming ? 15f : 1f) ) * 0.5f + 1f;
+		_innerColorStrength = float.Lerp( _innerColorStrength, strengthMult, Time.Delta * 10f );
+		_matCrystalInside?.Set( "g_vColorTint", ColorCrystalInside * _innerColorStrength );
+	}
+
 	Vector3 lastBeamPos;
 
 	protected virtual void UpdateEffects()
 	{
+		UpdateMaterials();
+		
 		if ( !Owner.IsValid() || !Beaming )
 		{
 			KillEffects();
 			return;
 		}
-
+		
 		if ( grabbed && !GrabbedObject.IsValid() )
 		{
 			DisableHighlights( lastGrabbedObject );
@@ -186,14 +232,13 @@ public partial class PhysGun
 		
 		var distance = startPos.Distance( endPos );
 		var targetMiddle = startPos + rotation.Forward * distance * 0.33f;
-		targetMiddle += Noise.FbmVector(2, Time.Now * 400f, Time.Now * 100f);
 		
 		if ( !justEnabled )
 		{
 			// If the beam halved or more in a single frame, snap the spring to the new position to avoid shakiness
 			if ( _prevBeamDistance > 1f && distance / _prevBeamDistance < 0.5f )
 			{
-				middleSpring = new Vector3.SpringDamped( targetMiddle, targetMiddle, 4, 0.2f );
+				middleSpring = new Vector3.SpringDamped( targetMiddle, targetMiddle, 12, 0.5f );
 			}
 
 			// Ensure the middle point is never behind the first one
@@ -201,7 +246,7 @@ public partial class PhysGun
 			if ( alongFwd < 0 )
 			{
 				var clamped = middleSpring.Current - rotation.Forward * alongFwd;
-				middleSpring = new Vector3.SpringDamped( clamped, targetMiddle, 4, 0.2f );
+				middleSpring = new Vector3.SpringDamped( clamped, targetMiddle, 12, 0.5f );
 			}
 		}
 
@@ -218,7 +263,7 @@ public partial class PhysGun
 			BeamRenderer.GameObject.Enabled = true;
 			_prevBeamDistance = distance;
 			BeamRenderer.VectorPoints[1] = targetMiddle;
-			middleSpring = new Vector3.SpringDamped( targetMiddle, targetMiddle, 4, 0.2f );
+			middleSpring = new Vector3.SpringDamped( targetMiddle, targetMiddle, 12, 0.5f );
 		}
 
 	}

--- a/Code/Components/Weapons/PhysGun.cs
+++ b/Code/Components/Weapons/PhysGun.cs
@@ -67,6 +67,7 @@ public partial class PhysGun : BaseWeapon, Component.INetworkListener
 		base.OnDisabled();
 		TryEndGrab();
 		StopBeamSound();
+		CleanupMaterials();
 	}
 
 	protected override void OnPreRender()

--- a/Code/Components/Weapons/PhysGun.cs
+++ b/Code/Components/Weapons/PhysGun.cs
@@ -363,5 +363,7 @@ public partial class PhysGun : BaseWeapon, Component.INetworkListener
 		PhysicsBody body = GetBody( gameObject, bone );
 		if ( body.IsValid() )
 			body.BodyType = PhysicsBodyType.Dynamic;
+		
+		UnFreezeEffects();
 	}
 }


### PR DESCRIPTION
Fixes physgun effects by adding the ones Facepunch made per #95 . Adds an optional World Model preset to prevent attached effects from being hidden in first person.